### PR TITLE
fix: remove unused testing npms

### DIFF
--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -4,32 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "^7.8.3"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
-			}
-		},
 		"@davinci/core": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.1.tgz",
-			"integrity": "sha512-T/NGab0+rfKpPSPeIJnra9dXGj/LN98inTiPXHIR9N8fp7YfUqf7M0Xjet5uivISZTACi4ga2NtJ9LE1JueJmw==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.2.tgz",
+			"integrity": "sha512-nJEp3QEFBqLiEju2L5XdsCKUoZ0CASBP20YMZSc0QMWQPB/lAX/hW5QeLwUh2BqGqG8F7VE9D9RatJkvaCS+mQ==",
 			"requires": {
-				"@davinci/reflector": "^0.11.1",
+				"@davinci/reflector": "^1.0.0",
 				"@godaddy/terminus": "4.1.0",
 				"@types/mocha": "^5.2.6",
 				"ajv": "6.2.1",
@@ -49,18 +29,18 @@
 			}
 		},
 		"@davinci/graphql": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@davinci/graphql/-/graphql-0.12.1.tgz",
-			"integrity": "sha512-BKWlhJi51vYXK+FDBaogrD2lIbPPoZLqHJ9+qX7fO9OczceJERB2lQPqiyVJE2xAEHWELVwFUuKhGii4vquYug==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@davinci/graphql/-/graphql-1.1.4.tgz",
+			"integrity": "sha512-BdpNHU9BnwZMx624nNTQQTK722WK5nICMq9D/SsZ1f8gHPpbpwy5yMB18RIjqv5AKqooAsly+IIKoD+pSs61bw==",
 			"requires": {
-				"@davinci/core": "^0.17.1",
-				"@davinci/reflector": "^0.11.1",
+				"@davinci/core": "^0.17.2",
+				"@davinci/reflector": "^1.0.0",
 				"bluebird": "3.7.2",
 				"debug": "^4.1.1",
 				"express-graphql": "0.9.0",
 				"graphql": "14.4.2",
 				"graphql-iso-date": "3.6.1",
-				"lodash": "4.17.11"
+				"lodash": "4.17.13"
 			},
 			"dependencies": {
 				"bluebird": {
@@ -69,19 +49,19 @@
 					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+					"version": "4.17.13",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+					"integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
 				}
 			}
 		},
 		"@davinci/mongoose": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.1.tgz",
-			"integrity": "sha512-w9jhHLep1YpT+DcOWGhvNQ3IbpC9SU+mgYwB+8+XH9k2b1k5ythtjVu73kCYO0ZAsjkV8cH0WOA66HQKxB7kwg==",
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.3.tgz",
+			"integrity": "sha512-QB1vF6Lc18N8mqR7ef/QywOuxF0bQA+0kE7NQo1Vzt0NW38ve+IAHQ0Pa5d3HPPjPc9+z630c8xKvqo0ydiNPQ==",
 			"requires": {
-				"@davinci/core": "^0.17.1",
-				"@davinci/reflector": "^0.11.1",
+				"@davinci/core": "^0.17.2",
+				"@davinci/reflector": "^1.0.0",
 				"bluebird": "3.7.1",
 				"debug": "^4.1.1",
 				"lodash": "4.17.15"
@@ -95,9 +75,9 @@
 			}
 		},
 		"@davinci/reflector": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-0.11.1.tgz",
-			"integrity": "sha512-qr7FtK8YOC4s3B4h+OvdgoHENY8JbO89Myw0KcQWc965+ohGM0pp1AiYuS7lZSwf0Tg5NgtWc/aP0zjapKN6fw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.0.tgz",
+			"integrity": "sha512-un/Ly0wDU3YW1a3h9dRh+Cqw/m825P4jbeg4fORzU0gXVrOGZkXFuUplLilpWCPkeXFkucyby12eh6E5JmxZqA==",
 			"requires": {
 				"reflect-metadata": "0.1.13"
 			}
@@ -203,52 +183,16 @@
 				"json-schema-traverse": "^0.3.0"
 			}
 		},
-		"ansi-colors": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-			"dev": true
-		},
-		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
 		"arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true
 		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.1",
@@ -287,22 +231,6 @@
 				}
 			}
 		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
@@ -314,110 +242,10 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
-		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -447,21 +275,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -472,57 +285,15 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
-		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"es-abstract": {
-			"version": "1.17.4",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-			"dev": true,
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			}
 		},
 		"es6-promisify": {
 			"version": "6.1.1",
@@ -533,24 +304,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -626,13 +379,13 @@
 					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 				},
 				"http-errors": {
-					"version": "1.7.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-					"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+					"integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
 					"requires": {
 						"depd": "~1.1.2",
 						"inherits": "2.0.4",
-						"setprototypeof": "1.1.1",
+						"setprototypeof": "1.2.0",
 						"statuses": ">= 1.5.0 < 2",
 						"toidentifier": "1.0.0"
 					}
@@ -659,12 +412,31 @@
 						"http-errors": "1.7.3",
 						"iconv-lite": "0.4.24",
 						"unpipe": "1.0.0"
+					},
+					"dependencies": {
+						"http-errors": {
+							"version": "1.7.3",
+							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+							"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+							"requires": {
+								"depd": "~1.1.2",
+								"inherits": "2.0.4",
+								"setprototypeof": "1.1.1",
+								"statuses": ">= 1.5.0 < 2",
+								"toidentifier": "1.0.0"
+							}
+						},
+						"setprototypeof": {
+							"version": "1.1.1",
+							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+							"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+						}
 					}
 				},
 				"setprototypeof": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-					"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 				},
 				"statuses": {
 					"version": "1.5.0",
@@ -712,24 +484,6 @@
 				}
 			}
 		},
-		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^3.0.0"
-			}
-		},
-		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "~2.0.3"
-			}
-		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -739,38 +493,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
-		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
 		},
 		"graphql": {
 			"version": "14.4.2",
@@ -784,39 +506,6 @@
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
 			"integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
 		},
 		"http-errors": {
 			"version": "1.6.3",
@@ -837,16 +526,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -857,74 +536,10 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
 			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
-		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-			"dev": true
-		},
-		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-			"dev": true
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
-		},
-		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
-		},
-		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
 		"iterall": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
@@ -936,29 +551,10 @@
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
 			"integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
 		},
-		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			}
-		},
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1"
-			}
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -997,78 +593,6 @@
 			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
 				"mime-db": "1.43.0"
-			}
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
-		"mocha": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-			"integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "3.2.3",
-				"browser-stdout": "1.3.1",
-				"debug": "3.2.6",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"find-up": "3.0.0",
-				"glob": "7.1.3",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.13.1",
-				"log-symbols": "2.2.0",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"ms": "2.1.1",
-				"node-environment-flags": "1.0.5",
-				"object.assign": "4.1.0",
-				"strip-json-comments": "2.0.1",
-				"supports-color": "6.0.0",
-				"which": "1.3.1",
-				"wide-align": "1.1.3",
-				"yargs": "13.3.0",
-				"yargs-parser": "13.1.1",
-				"yargs-unparser": "1.6.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
 			}
 		},
 		"mongodb": {
@@ -1146,50 +670,6 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
-		"node-environment-flags": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-			"dev": true,
-			"requires": {
-				"object.getownpropertydescriptors": "^2.0.3",
-				"semver": "^5.7.0"
-			}
-		},
-		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			}
-		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1198,61 +678,10 @@
 				"ee-first": "1.1.1"
 			}
 		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"p-limit": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-			"dev": true,
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.0.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
-		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
-		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -1304,18 +733,6 @@
 			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
 			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
 		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
 		"require_optional": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -1323,15 +740,6 @@
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
-			}
-		},
-		"resolve": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
-			"requires": {
-				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-from": {
@@ -1400,70 +808,10 @@
 				"send": "0.16.2"
 			}
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
 			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-		},
-		"should": {
-			"version": "13.2.3",
-			"resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
-			"integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-			"dev": true,
-			"requires": {
-				"should-equal": "^2.0.0",
-				"should-format": "^3.0.3",
-				"should-type": "^1.4.0",
-				"should-type-adaptors": "^1.0.1",
-				"should-util": "^1.0.0"
-			}
-		},
-		"should-equal": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
-			"integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.4.0"
-			}
-		},
-		"should-format": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.3.0",
-				"should-type-adaptors": "^1.0.1"
-			}
-		},
-		"should-type": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
-			"dev": true
-		},
-		"should-type-adaptors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.3.0",
-				"should-util": "^1.0.0"
-			}
-		},
-		"should-util": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-			"integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-			"dev": true
 		},
 		"sift": {
 			"version": "7.0.1",
@@ -1491,12 +839,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1507,64 +849,10 @@
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
 		},
-		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
-			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-			"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"swagger-ui-dist": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.1.tgz",
-			"integrity": "sha512-Sw/K95j1pT9TZtLKiHDEml7YqcXC9thTTQjxrvNgd9j1KzOIxpo/5lhHuUMAN/hxVAHetzmcBcQaBjywRXog8w=="
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.28.0.tgz",
+			"integrity": "sha512-aPkfTzPv9djSiZI1NUkWr5HynCUsH+jaJ0WSx+/t19wq7MMGg9clHm9nGoIpAtqml1G51ofI+I75Ym72pukzFg=="
 		},
 		"swagger-ui-express": {
 			"version": "4.1.4",
@@ -1606,44 +894,6 @@
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
-		"tslint": {
-			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^4.0.1",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.13.1",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.29.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-					"dev": true
-				}
-			}
-		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1673,148 +923,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yargs": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-			"dev": true,
-			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-			"dev": true,
-			"requires": {
-				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
-				"yargs": "^13.3.0"
-			}
 		},
 		"yn": {
 			"version": "3.1.1",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -22,12 +22,8 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.16.1",
-		"@types/mocha": "^5.2.6",
-		"mocha": "^6.1.4",
-		"should": "^13.2.3",
 		"ts-node": "^8.1.0",
 		"tslib": "^1.9.3",
-		"tslint": "^5.16.0",
 		"typescript": "^3.7.5"
 	}
 }

--- a/examples/rest/package-lock.json
+++ b/examples/rest/package-lock.json
@@ -1,35 +1,15 @@
 {
-	"name": "crm",
+	"name": "@davinci/example-rest",
 	"version": "0.11.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "^7.8.3"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
-			}
-		},
 		"@davinci/core": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.1.tgz",
-			"integrity": "sha512-T/NGab0+rfKpPSPeIJnra9dXGj/LN98inTiPXHIR9N8fp7YfUqf7M0Xjet5uivISZTACi4ga2NtJ9LE1JueJmw==",
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.2.tgz",
+			"integrity": "sha512-nJEp3QEFBqLiEju2L5XdsCKUoZ0CASBP20YMZSc0QMWQPB/lAX/hW5QeLwUh2BqGqG8F7VE9D9RatJkvaCS+mQ==",
 			"requires": {
-				"@davinci/reflector": "^0.11.1",
+				"@davinci/reflector": "^1.0.0",
 				"@godaddy/terminus": "4.1.0",
 				"@types/mocha": "^5.2.6",
 				"ajv": "6.2.1",
@@ -49,12 +29,12 @@
 			}
 		},
 		"@davinci/mongoose": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.1.tgz",
-			"integrity": "sha512-w9jhHLep1YpT+DcOWGhvNQ3IbpC9SU+mgYwB+8+XH9k2b1k5ythtjVu73kCYO0ZAsjkV8cH0WOA66HQKxB7kwg==",
+			"version": "0.14.3",
+			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.3.tgz",
+			"integrity": "sha512-QB1vF6Lc18N8mqR7ef/QywOuxF0bQA+0kE7NQo1Vzt0NW38ve+IAHQ0Pa5d3HPPjPc9+z630c8xKvqo0ydiNPQ==",
 			"requires": {
-				"@davinci/core": "^0.17.1",
-				"@davinci/reflector": "^0.11.1",
+				"@davinci/core": "^0.17.2",
+				"@davinci/reflector": "^1.0.0",
 				"bluebird": "3.7.1",
 				"debug": "^4.1.1",
 				"lodash": "4.17.15"
@@ -68,9 +48,9 @@
 			}
 		},
 		"@davinci/reflector": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-0.11.1.tgz",
-			"integrity": "sha512-qr7FtK8YOC4s3B4h+OvdgoHENY8JbO89Myw0KcQWc965+ohGM0pp1AiYuS7lZSwf0Tg5NgtWc/aP0zjapKN6fw==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.0.tgz",
+			"integrity": "sha512-un/Ly0wDU3YW1a3h9dRh+Cqw/m825P4jbeg4fORzU0gXVrOGZkXFuUplLilpWCPkeXFkucyby12eh6E5JmxZqA==",
 			"requires": {
 				"reflect-metadata": "0.1.13"
 			}
@@ -176,52 +156,16 @@
 				"json-schema-traverse": "^0.3.0"
 			}
 		},
-		"ansi-colors": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-			"dev": true
-		},
-		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
 		"arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true
 		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
 		},
 		"bluebird": {
 			"version": "3.5.1",
@@ -260,22 +204,6 @@
 				}
 			}
 		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"browser-stdout": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-			"dev": true
-		},
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
@@ -287,110 +215,10 @@
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
 		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
-		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
-		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"dependencies": {
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"cliui": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^3.1.0",
-				"strip-ansi": "^5.2.0",
-				"wrap-ansi": "^5.1.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -420,21 +248,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true
-		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -445,57 +258,15 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
-		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-			"dev": true
-		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
-		"emoji-regex": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-			"dev": true
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"es-abstract": {
-			"version": "1.17.4",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-			"dev": true,
-			"requires": {
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
-				"object-inspect": "^1.7.0",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
-			}
 		},
 		"es6-promisify": {
 			"version": "6.1.1",
@@ -506,24 +277,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -621,24 +374,6 @@
 				}
 			}
 		},
-		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^3.0.0"
-			}
-		},
-		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-			"dev": true,
-			"requires": {
-				"is-buffer": "~2.0.3"
-			}
-		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -648,71 +383,6 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
-		},
-		"get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true
-		},
-		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-			"dev": true,
-			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
-		},
-		"he": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-			"dev": true
 		},
 		"http-errors": {
 			"version": "1.6.3",
@@ -733,16 +403,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -752,70 +412,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
 			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-		},
-		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-			"dev": true
-		},
-		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-			"dev": true
-		},
-		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
-		},
-		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
-		},
-		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-			"dev": true,
-			"requires": {
-				"has": "^1.0.3"
-			}
-		},
-		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.1"
-			}
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
 		},
 		"json-schema-traverse": {
 			"version": "0.3.1",
@@ -827,29 +423,10 @@
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
 			"integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
 		},
-		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			}
-		},
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1"
-			}
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -888,78 +465,6 @@
 			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
 				"mime-db": "1.43.0"
-			}
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
-			"requires": {
-				"brace-expansion": "^1.1.7"
-			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
-		"mocha": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-			"integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
-			"dev": true,
-			"requires": {
-				"ansi-colors": "3.2.3",
-				"browser-stdout": "1.3.1",
-				"debug": "3.2.6",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"find-up": "3.0.0",
-				"glob": "7.1.3",
-				"growl": "1.10.5",
-				"he": "1.2.0",
-				"js-yaml": "3.13.1",
-				"log-symbols": "2.2.0",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"ms": "2.1.1",
-				"node-environment-flags": "1.0.5",
-				"object.assign": "4.1.0",
-				"strip-json-comments": "2.0.1",
-				"supports-color": "6.0.0",
-				"which": "1.3.1",
-				"wide-align": "1.1.3",
-				"yargs": "13.3.0",
-				"yargs-parser": "13.1.1",
-				"yargs-unparser": "1.6.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-					"dev": true
-				}
 			}
 		},
 		"mongodb": {
@@ -1037,50 +542,6 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
-		"node-environment-flags": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-			"dev": true,
-			"requires": {
-				"object.getownpropertydescriptors": "^2.0.3",
-				"semver": "^5.7.0"
-			}
-		},
-		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-			"dev": true
-		},
-		"object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
-			}
-		},
 		"on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -1089,61 +550,10 @@
 				"ee-first": "1.1.1"
 			}
 		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
-			"requires": {
-				"wrappy": "1"
-			}
-		},
-		"p-limit": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-			"dev": true,
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^2.0.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
-		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
-		"path-exists": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -1195,18 +605,6 @@
 			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
 			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
 		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-			"dev": true
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true
-		},
 		"require_optional": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
@@ -1214,15 +612,6 @@
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
-			}
-		},
-		"resolve": {
-			"version": "1.15.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
-			"requires": {
-				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-from": {
@@ -1291,70 +680,10 @@
 				"send": "0.16.2"
 			}
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
-		},
 		"setprototypeof": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
 			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-		},
-		"should": {
-			"version": "13.2.3",
-			"resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
-			"integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
-			"dev": true,
-			"requires": {
-				"should-equal": "^2.0.0",
-				"should-format": "^3.0.3",
-				"should-type": "^1.4.0",
-				"should-type-adaptors": "^1.0.1",
-				"should-util": "^1.0.0"
-			}
-		},
-		"should-equal": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
-			"integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.4.0"
-			}
-		},
-		"should-format": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
-			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.3.0",
-				"should-type-adaptors": "^1.0.1"
-			}
-		},
-		"should-type": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
-			"integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
-			"dev": true
-		},
-		"should-type-adaptors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
-			"integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
-			"dev": true,
-			"requires": {
-				"should-type": "^1.3.0",
-				"should-util": "^1.0.0"
-			}
-		},
-		"should-util": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
-			"integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
-			"dev": true
 		},
 		"sift": {
 			"version": "7.0.1",
@@ -1382,12 +711,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
 		"statuses": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1398,64 +721,10 @@
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
 		},
-		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
-			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			}
-		},
-		"string.prototype.trimleft": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"function-bind": "^1.1.1"
-			}
-		},
-		"strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^3.0.0"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
-		},
-		"supports-color": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-			"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"swagger-ui-dist": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.1.tgz",
-			"integrity": "sha512-Sw/K95j1pT9TZtLKiHDEml7YqcXC9thTTQjxrvNgd9j1KzOIxpo/5lhHuUMAN/hxVAHetzmcBcQaBjywRXog8w=="
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.28.0.tgz",
+			"integrity": "sha512-aPkfTzPv9djSiZI1NUkWr5HynCUsH+jaJ0WSx+/t19wq7MMGg9clHm9nGoIpAtqml1G51ofI+I75Ym72pukzFg=="
 		},
 		"swagger-ui-express": {
 			"version": "4.1.4",
@@ -1492,44 +761,6 @@
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
-		"tslint": {
-			"version": "5.20.1",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^4.0.1",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.13.1",
-				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.29.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-					"dev": true
-				}
-			}
-		},
-		"tsutils": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"dev": true,
-			"requires": {
-				"tslib": "^1.8.1"
-			}
-		},
 		"type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1559,148 +790,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-		},
-		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"dev": true,
-			"requires": {
-				"isexe": "^2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wide-align": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"wrap-ansi": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.0",
-				"string-width": "^3.0.0",
-				"strip-ansi": "^5.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
-		},
-		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-			"dev": true
-		},
-		"yargs": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-			"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-			"dev": true,
-			"requires": {
-				"cliui": "^5.0.0",
-				"find-up": "^3.0.0",
-				"get-caller-file": "^2.0.1",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^3.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^13.1.1"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^7.0.1",
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^4.1.0"
-					}
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
-		},
-		"yargs-unparser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-			"dev": true,
-			"requires": {
-				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
-				"yargs": "^13.3.0"
-			}
 		},
 		"yn": {
 			"version": "3.1.1",

--- a/examples/rest/package.json
+++ b/examples/rest/package.json
@@ -21,12 +21,8 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.16.1",
-		"@types/mocha": "^5.2.6",
-		"mocha": "^6.1.4",
-		"should": "^13.2.3",
 		"ts-node": "^8.1.0",
 		"tslib": "^1.9.3",
-		"tslint": "^5.16.0",
 		"typescript": "^3.7.5"
 	}
 }


### PR DESCRIPTION
This PR removes some testing/linting libraries (`mocha`, `should`, `tslint` and `@types/mocha`) from the example projects since they weren't actually in use and one of mocha's dependencies had a security vulnerability. 