### PR TITLE
feat: added the ability to specify enum parameter types

### DIFF
--- a/packages/core/src/route/openapi/createPaths.ts
+++ b/packages/core/src/route/openapi/createPaths.ts
@@ -12,7 +12,7 @@ import { getSchemaDefinition } from './createSchemaDefinition';
 
 const getParameterDefinition = methodParameterConfig => {
 	const {
-		options: { type, ...options }
+		options: { type, enum: enumOptions, ...options }
 	} = methodParameterConfig;
 	const paramDefinition = { ...options };
 	// handling special parameters
@@ -20,10 +20,28 @@ const getParameterDefinition = methodParameterConfig => {
 		paramDefinition.schema = { type: methodParameterConfig.type };
 	} else {
 		const schema = methodParameterConfig?.options?.schema;
+
 		if (schema) {
 			paramDefinition.schema = {
 				...schema
 			};
+		} else if (enumOptions?.length) {
+			const { schemas, definitions } = enumOptions.reduce(
+				(acc, enumType) => {
+					const { schema: s, definitions: d } = getSchemaDefinition(enumType);
+					acc.schemas.push(s);
+					acc.definitions = { ...acc.definitions, ...d };
+					return acc;
+				},
+				{
+					schemas: [],
+					definitions: {}
+				}
+			);
+
+			paramDefinition.schema = { oneOf: schemas };
+
+			return { paramDefinition, definitions };
 		} else {
 			const { schema: s, definitions } = getSchemaDefinition(type);
 			paramDefinition.schema = s;

--- a/packages/core/src/route/types.ts
+++ b/packages/core/src/route/types.ts
@@ -29,6 +29,7 @@ export interface ISchema {
 export interface IMethodParameterBase {
 	name?: string;
 	type?: TypeValue;
+	enum?: TypeValue[];
 	description?: string;
 	required?: boolean;
 	schema?: ISchema;

--- a/packages/core/test/unit/route/decorators/route.test.ts
+++ b/packages/core/test/unit/route/decorators/route.test.ts
@@ -246,10 +246,11 @@ describe('route decorators', () => {
 				methodName: 'myMethod',
 				index: 0,
 				options: {
-					name: 'correctName',
-					in: 'query'
+					name: 'test',
+					in: 'query',
+					type: [String]
 				},
-				type: String
+				type: [String]
 			});
 		});
 	});

--- a/packages/core/test/unit/route/openapi/createPaths.test.ts
+++ b/packages/core/test/unit/route/openapi/createPaths.test.ts
@@ -137,4 +137,67 @@ describe('createPathsDefinition', () => {
 			}
 		});
 	});
+
+	it('should support passing a enum type to the methods parameters', () => {
+		class Item {
+			@openapi.prop()
+			barcode: string;
+		}
+
+		// the body can either be an item, or an array of items
+		@route.controller({})
+		class MyClass {
+			@route.post({ path: '/', summary: 'Create', description: 'Create one or multiple items' })
+			post(@route.body({ enum: [Item, [Item]] }) items: Item | Item[]) {
+				return items;
+			}
+		}
+
+		const { paths } = createPathsDefinition(MyClass);
+		should(paths).be.deepEqual({
+			'/': {
+				post: {
+					summary: 'Create',
+					description: 'Create one or multiple items',
+					operationId: 'post',
+					parameters: [
+						{
+							in: 'body',
+							name: 'items',
+							schema: {
+								oneOf: [
+									{
+										type: 'object',
+										title: 'Item',
+										properties: {
+											barcode: {
+												type: 'string'
+											}
+										}
+									},
+									{
+										type: 'array',
+										items: {
+											type: 'object',
+											title: 'Item',
+											properties: {
+												barcode: {
+													type: 'string'
+												}
+											}
+										}
+									}
+								]
+							}
+						}
+					],
+					responses: {
+						'200': {
+							description: 'Success'
+						}
+					}
+				}
+			}
+		});
+	});
 });


### PR DESCRIPTION
Related to: https://github.com/Oneflow/workforce-api/pull/446#issue-442644353

#### Example:
```ts
@route.controller({ basepath: '/' })
class MyClass {
    @route.post({ path: '/', summary: 'Create', description: 'Create a Planet or a Star' })
    // we can now pass an enum type. In this case, the body could either be a Planet or a Star
    post(@route.body({ enum: [Planet, Star] }) items: Planet | Star) {
        return items;
    }
}
```