### PR TITLE
fix: don't use console

### DIFF
--- a/packages/core/src/express/middlewares/errorHandler.ts
+++ b/packages/core/src/express/middlewares/errorHandler.ts
@@ -39,7 +39,6 @@ export default ({ exposeStack = false } = {}) => {
 			delete output.stack;
 		}
 
-		console.error(error);
 		res.status(error.code);
 		res.set('Content-Type', 'application/json');
 		res.json(output);


### PR DESCRIPTION
This `console.error` was causing a huge stack trace to be dumped in the middle of some mocha unit tests I was running which caused me to spend time investigating why it was happening.

We already use `debug` to log the error object further up the function, it doesn't seem useful to also console.error the object again later on. Having said that, we could potentially move the debug call further down to give us a better idea of the error we actually return to the client?
