### PR TITLE
feat: allow passing the express instance as parameter

### DIFF
--- a/examples/rest/src/index.ts
+++ b/examples/rest/src/index.ts
@@ -40,7 +40,7 @@ const expressApp: Express = express();
 const createContext = ({ req }): Context => ({ accountId: req.headers['x-oneflow-accountid'] });
 
 createApp(expressApp, options, app => {
-	app.use(createRouter(CustomerController, 'Customer', createContext));
+	createRouter(CustomerController, 'Customer', createContext, app);
 });
 
 if (require.main === module) {

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -5,7 +5,7 @@
 
 import Ajv from 'ajv';
 import Debug from 'debug';
-import express, { Express, NextFunction, Response, Router } from 'express';
+import express, { NextFunction, Response, Router } from 'express';
 import _ from 'lodash';
 import _fp from 'lodash/fp';
 import Promise from 'bluebird';
@@ -311,7 +311,7 @@ const createRouterAndSwaggerDoc = (
 	Controller: ClassType,
 	rsName?: string | null,
 	contextFactory?: ContextFactory | null,
-	app?: DaVinciExpress | Express
+	router: Router = express.Router()
 ): Router | DaVinciExpress => {
 	// need to validate the inputs here
 	validateController(Controller);
@@ -349,9 +349,6 @@ const createRouterAndSwaggerDoc = (
 
 	// now process the swagger structure and get an array of method/path mappings to handlers
 	const routes = createRouteHandlers(controller, definition, validationOptions, contextFactory);
-
-	// create the router or use the provided app
-	const router = app ?? express.Router();
 
 	// add them to the router
 	routes.forEach(route => {

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -67,7 +67,7 @@ describe('createRouter', () => {
 			done();
 		});
 
-		it('should register the routes to the app instance provided as parameter', () => {
+		it('should register the routes to the router instance provided as parameter', () => {
 			let app = express();
 
 			@route.controller({ basepath: '/api/test' })

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import should from 'should';
 import Sinon from 'sinon';
+import express from 'express';
 import MongooseController from '../../support/MongooseController';
 import createRouter, { createRouteHandlers } from '../../../src/route/createRouter';
 import { route } from '../../../src/route';
@@ -64,6 +65,25 @@ describe('createRouter', () => {
 			router.stack[0].route.should.have.property('path').equal('/:id');
 			router.stack[0].route.should.have.property('methods').deepEqual({ delete: true });
 			done();
+		});
+
+		it('should register the routes to the app instance provided as parameter', () => {
+			let app = express();
+
+			@route.controller({ basepath: '/api/test' })
+			class TestController {
+				@route.get({ path: '/hello', summary: 'Find' })
+				find() {}
+			}
+			const router = createRouter(TestController, 'test', null, app);
+
+			should(router).be.equal(app);
+			should(app._router.stack[2].route).match({
+				path: '/api/test/hello',
+				methods: {
+					get: true
+				}
+			});
 		});
 	});
 


### PR DESCRIPTION
So that the routes get attached directly into it.
Needed for displaying correctly the name of the routes in newrelic APM.