### PR TITLE
fix: update lodash due to security vulnerability

### DIFF
--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -4,93 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.2.tgz",
-			"integrity": "sha512-nJEp3QEFBqLiEju2L5XdsCKUoZ0CASBP20YMZSc0QMWQPB/lAX/hW5QeLwUh2BqGqG8F7VE9D9RatJkvaCS+mQ==",
-			"requires": {
-				"@davinci/reflector": "^1.0.0",
-				"@godaddy/terminus": "4.1.0",
-				"@types/mocha": "^5.2.6",
-				"ajv": "6.2.1",
-				"bluebird": "3.5.0",
-				"debug": "^4.1.1",
-				"express": "^4.16.4",
-				"lodash": "4.17.15",
-				"require-dir": "0.3.2",
-				"swagger-ui-express": "^4.0.7"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-					"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-				}
-			}
-		},
-		"@davinci/graphql": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@davinci/graphql/-/graphql-1.1.4.tgz",
-			"integrity": "sha512-BdpNHU9BnwZMx624nNTQQTK722WK5nICMq9D/SsZ1f8gHPpbpwy5yMB18RIjqv5AKqooAsly+IIKoD+pSs61bw==",
-			"requires": {
-				"@davinci/core": "^0.17.2",
-				"@davinci/reflector": "^1.0.0",
-				"bluebird": "3.7.2",
-				"debug": "^4.1.1",
-				"express-graphql": "0.9.0",
-				"graphql": "14.4.2",
-				"graphql-iso-date": "3.6.1",
-				"lodash": "4.17.13"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-				},
-				"lodash": {
-					"version": "4.17.13",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-					"integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
-				}
-			}
-		},
-		"@davinci/mongoose": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.3.tgz",
-			"integrity": "sha512-QB1vF6Lc18N8mqR7ef/QywOuxF0bQA+0kE7NQo1Vzt0NW38ve+IAHQ0Pa5d3HPPjPc9+z630c8xKvqo0ydiNPQ==",
-			"requires": {
-				"@davinci/core": "^0.17.2",
-				"@davinci/reflector": "^1.0.0",
-				"bluebird": "3.7.1",
-				"debug": "^4.1.1",
-				"lodash": "4.17.15"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.1",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-					"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.0.tgz",
-			"integrity": "sha512-un/Ly0wDU3YW1a3h9dRh+Cqw/m825P4jbeg4fORzU0gXVrOGZkXFuUplLilpWCPkeXFkucyby12eh6E5JmxZqA==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.1.0.tgz",
-			"integrity": "sha512-48hGiwgSI/qHUXC+p2Qc73NvlMBO+Q1O4HhglTg7km8pfhDM79p/vFO5HD9/f7PCoLY/5p3kl/Tb8O2aDYgp0g==",
-			"requires": {
-				"es6-promisify": "^6.0.0",
-				"stoppable": "^1.0.5"
-			}
-		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -137,11 +50,6 @@
 			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
 			"dev": true
 		},
-		"@types/mocha": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
-		},
 		"@types/node": {
 			"version": "13.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
@@ -171,16 +79,6 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-			"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
-			"requires": {
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"arg": {
@@ -295,11 +193,6 @@
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
-		"es6-promisify": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-			"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
-		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -362,99 +255,6 @@
 				}
 			}
 		},
-		"express-graphql": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
-			"integrity": "sha512-wccd9Lb6oeJ8yHpUs/8LcnGjFUUQYmOG9A5BNLybRdCzGw0PeUrtBxsIR8bfiur6uSW4OvPkVDoYH06z6/N9+w==",
-			"requires": {
-				"accepts": "^1.3.7",
-				"content-type": "^1.0.4",
-				"http-errors": "^1.7.3",
-				"raw-body": "^2.4.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-				},
-				"http-errors": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-					"integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.4",
-						"setprototypeof": "1.2.0",
-						"statuses": ">= 1.5.0 < 2",
-						"toidentifier": "1.0.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-				},
-				"raw-body": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-					"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-					"requires": {
-						"bytes": "3.1.0",
-						"http-errors": "1.7.3",
-						"iconv-lite": "0.4.24",
-						"unpipe": "1.0.0"
-					},
-					"dependencies": {
-						"http-errors": {
-							"version": "1.7.3",
-							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-							"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-							"requires": {
-								"depd": "~1.1.2",
-								"inherits": "2.0.4",
-								"setprototypeof": "1.1.1",
-								"statuses": ">= 1.5.0 < 2",
-								"toidentifier": "1.0.0"
-							}
-						},
-						"setprototypeof": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-							"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-						}
-					}
-				},
-				"setprototypeof": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-				},
-				"statuses": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-				}
-			}
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -494,19 +294,6 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
-		"graphql": {
-			"version": "14.4.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-			"integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-			"requires": {
-				"iterall": "^1.2.2"
-			}
-		},
-		"graphql-iso-date": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
-			"integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
-		},
 		"http-errors": {
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -536,25 +323,15 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
 			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
-		"iterall": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
-		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
 		"kareem": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
 			"integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -718,20 +495,10 @@
 				"unpipe": "1.0.0"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-		},
-		"require-dir": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
-			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -843,29 +610,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
-		"swagger-ui-dist": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.28.0.tgz",
-			"integrity": "sha512-aPkfTzPv9djSiZI1NUkWr5HynCUsH+jaJ0WSx+/t19wq7MMGg9clHm9nGoIpAtqml1G51ofI+I75Ym72pukzFg=="
-		},
-		"swagger-ui-express": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
-			"integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"ts-node": {
 			"version": "8.6.2",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -17,7 +17,7 @@
 		"@davinci/mongoose": "^0.14.8",
 		"debug": "^4.1.1",
 		"express": "4.16.4",
-		"lodash": "^4.17.11",
+		"lodash": "4.17.19",
 		"mongoose": "5.7.5"
 	},
 	"devDependencies": {

--- a/examples/rest/package-lock.json
+++ b/examples/rest/package-lock.json
@@ -4,66 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "0.17.2",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.2.tgz",
-			"integrity": "sha512-nJEp3QEFBqLiEju2L5XdsCKUoZ0CASBP20YMZSc0QMWQPB/lAX/hW5QeLwUh2BqGqG8F7VE9D9RatJkvaCS+mQ==",
-			"requires": {
-				"@davinci/reflector": "^1.0.0",
-				"@godaddy/terminus": "4.1.0",
-				"@types/mocha": "^5.2.6",
-				"ajv": "6.2.1",
-				"bluebird": "3.5.0",
-				"debug": "^4.1.1",
-				"express": "^4.16.4",
-				"lodash": "4.17.15",
-				"require-dir": "0.3.2",
-				"swagger-ui-express": "^4.0.7"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-					"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-				}
-			}
-		},
-		"@davinci/mongoose": {
-			"version": "0.14.3",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.14.3.tgz",
-			"integrity": "sha512-QB1vF6Lc18N8mqR7ef/QywOuxF0bQA+0kE7NQo1Vzt0NW38ve+IAHQ0Pa5d3HPPjPc9+z630c8xKvqo0ydiNPQ==",
-			"requires": {
-				"@davinci/core": "^0.17.2",
-				"@davinci/reflector": "^1.0.0",
-				"bluebird": "3.7.1",
-				"debug": "^4.1.1",
-				"lodash": "4.17.15"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.1",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-					"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.0.tgz",
-			"integrity": "sha512-un/Ly0wDU3YW1a3h9dRh+Cqw/m825P4jbeg4fORzU0gXVrOGZkXFuUplLilpWCPkeXFkucyby12eh6E5JmxZqA==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.1.0.tgz",
-			"integrity": "sha512-48hGiwgSI/qHUXC+p2Qc73NvlMBO+Q1O4HhglTg7km8pfhDM79p/vFO5HD9/f7PCoLY/5p3kl/Tb8O2aDYgp0g==",
-			"requires": {
-				"es6-promisify": "^6.0.0",
-				"stoppable": "^1.0.5"
-			}
-		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -110,11 +50,6 @@
 			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
 			"dev": true
 		},
-		"@types/mocha": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
-		},
 		"@types/node": {
 			"version": "13.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
@@ -144,16 +79,6 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-			"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
-			"requires": {
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"arg": {
@@ -268,11 +193,6 @@
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
 			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
 		},
-		"es6-promisify": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-			"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
-		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -334,16 +254,6 @@
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"finalhandler": {
 			"version": "1.1.1",
@@ -413,20 +323,15 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
 			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
 		"kareem": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
 			"integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -590,20 +495,10 @@
 				"unpipe": "1.0.0"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-		},
-		"require-dir": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
-			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -715,24 +610,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
-		"swagger-ui-dist": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.28.0.tgz",
-			"integrity": "sha512-aPkfTzPv9djSiZI1NUkWr5HynCUsH+jaJ0WSx+/t19wq7MMGg9clHm9nGoIpAtqml1G51ofI+I75Ym72pukzFg=="
-		},
-		"swagger-ui-express": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
-			"integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
 		},
 		"ts-node": {
 			"version": "8.6.2",

--- a/examples/rest/package.json
+++ b/examples/rest/package.json
@@ -16,7 +16,7 @@
 		"@davinci/mongoose": "^0.14.8",
 		"debug": "^4.1.1",
 		"express": "4.16.4",
-		"lodash": "^4.17.11",
+		"lodash": "4.17.19",
 		"mongoose": "5.7.5"
 	},
 	"devDependencies": {

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -323,9 +323,9 @@
 			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"media-typer": {
 			"version": "0.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
 		"ajv": "6.2.1",
 		"bluebird": "3.5.0",
 		"debug": "^4.1.1",
-		"lodash": "4.17.15",
+		"lodash": "4.17.19",
 		"require-dir": "0.3.2",
 		"swagger-ui-express": "^4.0.7"
 	},

--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -4,52 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.1.tgz",
-			"integrity": "sha512-T/NGab0+rfKpPSPeIJnra9dXGj/LN98inTiPXHIR9N8fp7YfUqf7M0Xjet5uivISZTACi4ga2NtJ9LE1JueJmw==",
-			"requires": {
-				"@davinci/reflector": "^0.11.1",
-				"@godaddy/terminus": "4.1.0",
-				"@types/mocha": "^5.2.6",
-				"ajv": "6.2.1",
-				"bluebird": "3.5.0",
-				"debug": "^4.1.1",
-				"express": "^4.16.4",
-				"lodash": "4.17.15",
-				"require-dir": "0.3.2",
-				"swagger-ui-express": "^4.0.7"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-					"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-0.11.1.tgz",
-			"integrity": "sha512-qr7FtK8YOC4s3B4h+OvdgoHENY8JbO89Myw0KcQWc965+ohGM0pp1AiYuS7lZSwf0Tg5NgtWc/aP0zjapKN6fw==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.1.0.tgz",
-			"integrity": "sha512-48hGiwgSI/qHUXC+p2Qc73NvlMBO+Q1O4HhglTg7km8pfhDM79p/vFO5HD9/f7PCoLY/5p3kl/Tb8O2aDYgp0g==",
-			"requires": {
-				"es6-promisify": "^6.0.0",
-				"stoppable": "^1.0.5"
-			}
-		},
 		"@types/graphql": {
 			"version": "14.2.3",
 			"resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
@@ -59,7 +13,8 @@
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",
@@ -70,113 +25,20 @@
 				"negotiator": "0.6.2"
 			}
 		},
-		"ajv": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-			"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
-			"requires": {
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
-			}
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"http-errors": {
-					"version": "1.7.2",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-					"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.1",
-						"statuses": ">= 1.5.0 < 2",
-						"toidentifier": "1.0.0"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				},
-				"raw-body": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-					"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-					"requires": {
-						"bytes": "3.1.0",
-						"http-errors": "1.7.2",
-						"iconv-lite": "0.4.24",
-						"unpipe": "1.0.0"
-					}
-				}
-			}
 		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -191,88 +53,6 @@
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
 			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
 		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"es6-promisify": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-			"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
 		"express-graphql": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.9.0.tgz",
@@ -283,55 +63,6 @@
 				"http-errors": "^1.7.3",
 				"raw-body": "^2.4.1"
 			}
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"graphql": {
 			"version": "14.4.2",
@@ -371,45 +102,15 @@
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
-		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-		},
 		"iterall": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
 		"lodash": {
-			"version": "4.17.13",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-			"integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"mime-db": {
 			"version": "1.43.0",
@@ -434,43 +135,6 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-		},
-		"proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
-			}
-		},
-		"qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-		},
 		"raw-body": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
@@ -482,78 +146,10 @@
 				"unpipe": "1.0.0"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
-		"require-dir": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
-			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
-		},
-		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			}
 		},
 		"setprototypeof": {
 			"version": "1.1.1",
@@ -564,24 +160,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
-		"swagger-ui-dist": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.1.tgz",
-			"integrity": "sha512-Sw/K95j1pT9TZtLKiHDEml7YqcXC9thTTQjxrvNgd9j1KzOIxpo/5lhHuUMAN/hxVAHetzmcBcQaBjywRXog8w=="
-		},
-		"swagger-ui-express": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
-			"integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -594,15 +172,6 @@
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typescript": {
 			"version": "3.7.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
@@ -613,16 +182,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		}
 	}
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -21,7 +21,7 @@
 		"express-graphql": "0.9.0",
 		"graphql": "14.4.2",
 		"graphql-iso-date": "3.6.1",
-		"lodash": "4.17.13"
+		"lodash": "4.17.19"
 	},
 	"devDependencies": {
 		"@types/graphql": "14.2.3",

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -4,146 +4,16 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-0.17.1.tgz",
-			"integrity": "sha512-T/NGab0+rfKpPSPeIJnra9dXGj/LN98inTiPXHIR9N8fp7YfUqf7M0Xjet5uivISZTACi4ga2NtJ9LE1JueJmw==",
-			"requires": {
-				"@davinci/reflector": "^0.11.1",
-				"@godaddy/terminus": "4.1.0",
-				"@types/mocha": "^5.2.6",
-				"ajv": "6.2.1",
-				"bluebird": "3.5.0",
-				"debug": "^4.1.1",
-				"express": "^4.16.4",
-				"lodash": "4.17.15",
-				"require-dir": "0.3.2",
-				"swagger-ui-express": "^4.0.7"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-					"integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-0.11.1.tgz",
-			"integrity": "sha512-qr7FtK8YOC4s3B4h+OvdgoHENY8JbO89Myw0KcQWc965+ohGM0pp1AiYuS7lZSwf0Tg5NgtWc/aP0zjapKN6fw==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.1.0.tgz",
-			"integrity": "sha512-48hGiwgSI/qHUXC+p2Qc73NvlMBO+Q1O4HhglTg7km8pfhDM79p/vFO5HD9/f7PCoLY/5p3kl/Tb8O2aDYgp0g==",
-			"requires": {
-				"es6-promisify": "^6.0.0",
-				"stoppable": "^1.0.5"
-			}
-		},
-		"@types/mocha": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-			"integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
-			"requires": {
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
-			}
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-		},
 		"bluebird": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
 			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
 		},
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
 			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
 			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
-		"cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -153,177 +23,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"es6-promisify": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-			"integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
-		"fast-deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-		},
-		"fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
-			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			}
-		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
-		},
-		"json-schema-traverse": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-			"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-		},
 		"kareem": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
@@ -331,42 +30,9 @@
 			"dev": true
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-		},
-		"mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-		},
-		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-		},
-		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-			"requires": {
-				"mime-db": "1.44.0"
-			}
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"mongodb": {
 			"version": "3.3.2",
@@ -451,80 +117,17 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
-		},
 		"prettier": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
 			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
 			"dev": true
 		},
-		"proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
-			}
-		},
-		"qs": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-		},
-		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
-		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
 			"dev": true
-		},
-		"require-dir": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
-			"integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk="
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -545,76 +148,14 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
-		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			}
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"sift": {
 			"version": "7.0.1",
@@ -628,69 +169,17 @@
 			"integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
 			"dev": true
 		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
-		"swagger-ui-dist": {
-			"version": "3.25.1",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.1.tgz",
-			"integrity": "sha512-Sw/K95j1pT9TZtLKiHDEml7YqcXC9thTTQjxrvNgd9j1KzOIxpo/5lhHuUMAN/hxVAHetzmcBcQaBjywRXog8w=="
-		},
-		"swagger-ui-express": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
-			"integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-		},
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typescript": {
 			"version": "3.7.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
 			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
 			"dev": true
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		}
 	}
 }

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -22,7 +22,7 @@
 		"@davinci/reflector": "^1.0.0",
 		"bluebird": "3.7.1",
 		"debug": "^4.1.1",
-		"lodash": "4.17.15"
+		"lodash": "4.17.19"
 	},
 	"devDependencies": {
 		"mongoose": "5.7.5",


### PR DESCRIPTION
This PR updates lodash in all packages (as opposed to Dependabot's PRs which is one-per-package). 

The update fixes the following alerts:
https://github.com/HPInc/davinci/network/alerts
