### PR TITLE
fix: moved @types/mocha to devDependencies

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -24,7 +24,8 @@
 		"@types/mocha": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
 		},
 		"accepts": {
 			"version": "1.3.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
 	"dependencies": {
 		"@davinci/reflector": "^1.0.0",
 		"@godaddy/terminus": "4.1.0",
-		"@types/mocha": "^5.2.6",
 		"ajv": "6.2.1",
 		"bluebird": "3.5.0",
 		"debug": "^4.1.1",
@@ -29,6 +28,7 @@
 		"mongoose": "5.5.5"
 	},
 	"devDependencies": {
+		"@types/mocha": "^5.2.7",
 		"express": "^4.16.4",
 		"tslib": "^1.9.3",
 		"typescript": "^3.7.5"


### PR DESCRIPTION
As the title says - there's no need for `@types/mocha` to be a standard dependency, it's only useful for development/build. 