### PR TITLE
fix: rename swagger 'name' field to 'title'

### DIFF
--- a/docs/guide/basics/swagger-ui.md
+++ b/docs/guide/basics/swagger-ui.md
@@ -21,7 +21,7 @@ const options = {
 			path: '/api-doc.json',
 			options: {
 				info: {
-					name: 'Customer API',
+					title: 'Customer API',
 					version: packageJson.version
 				},
 				securityDefinitions: { Bearer: { type: 'apiKey', name: 'Authorization', in: 'header' } }


### PR DESCRIPTION
According to both Swagger/OpenAPI 2.0: 
https://swagger.io/specification/v2/#infoObject
and OpenAPI 3.0:
https://swagger.io/specification/#info-object

the `info` definition **requires** `title`, and `name` isn't a recognized property. 

This PR fixes the docs to describe that correctly.