### PR TITLE
feat: allow additional fields in openapi definition

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -379,6 +379,11 @@
 				"ee-first": "1.1.1"
 			}
 		},
+		"openapi-types": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-7.0.1.tgz",
+			"integrity": "sha512-6pi4/Fw+JIW1HHda2Ij7LRJ5QJ8f6YzaXnsRA6m44BJz8nLq/j5gVFzPBKJo+uOFhAeHqZC/3uzhTpYPga3Q/A=="
+		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
 		"bluebird": "3.5.0",
 		"debug": "^4.1.1",
 		"lodash": "4.17.19",
+		"openapi-types": "^7.0.1",
 		"require-dir": "0.3.2"
 	},
 	"peerDependencies": {

--- a/packages/core/src/route/decorators/openapi.ts
+++ b/packages/core/src/route/decorators/openapi.ts
@@ -5,7 +5,10 @@
 
 import { Reflector } from '@davinci/reflector';
 import _ from 'lodash';
-import { IPropDecoratorOptions, IPropDecoratorOptionsFactory, IPropDecoratorMetadata } from '../types';
+import {
+	IPropDecoratorOptions, IPropDecoratorOptionsFactory, IPropDecoratorMetadata,
+	IDefinitionDecoratorOptions
+} from '../types';
 
 /**
  * It annotates a variable as swagger definition property
@@ -31,7 +34,7 @@ export function prop(opts?: IPropDecoratorOptions | IPropDecoratorOptionsFactory
  * Its definition will be added in the `definitions` property
  * @param options
  */
-export function definition(options?: { title }) {
+export function definition(options?: IDefinitionDecoratorOptions) {
 	return function(target: Function): void {
 		Reflector.defineMetadata('davinci:openapi:definition', options, target);
 	};

--- a/packages/core/src/route/types.ts
+++ b/packages/core/src/route/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { TypeValue, TypeValueFactory, Maybe } from '@davinci/reflector';
+import { IJsonSchema } from 'openapi-types';
 
 export interface ISwaggerDefinition {
 	title?: string;
@@ -71,6 +72,12 @@ export interface PathsValidationOptions {
 	};
 }
 
+type IDecoratorOptionsFactory<T> = () => Maybe<T>;
+type IDecoratorMetadata<T> = {
+	key: string;
+	optsFactory?: IDecoratorOptionsFactory<T>;
+};
+
 /**
  * Something
  * @param type - Explicitly passed type
@@ -84,13 +91,10 @@ export interface IPropDecoratorOptions {
 	typeFactory?: TypeValueFactory;
 	required?: boolean;
 }
+export type IPropDecoratorOptionsFactory = IDecoratorOptionsFactory<IPropDecoratorOptions>;
+export type IPropDecoratorMetadata = IDecoratorMetadata<IPropDecoratorOptions>;
 
-export type IPropDecoratorOptionsFactory = () => Maybe<IPropDecoratorOptions>;
-
-export interface IPropDecoratorMetadata {
-	key: string;
-	optsFactory?: IPropDecoratorOptionsFactory;
-}
+export type IDefinitionDecoratorOptions = { title: any; } & Pick<IJsonSchema, 'dependencies' | 'oneOf' | 'allOf' | 'anyOf' | 'not'>;
 
 export interface IMethodResponseOutput {
 	description?: string;

--- a/packages/core/test/unit/route/openapi/createSchemaDefinition.test.ts
+++ b/packages/core/test/unit/route/openapi/createSchemaDefinition.test.ts
@@ -390,4 +390,51 @@ describe('createSchemaDefinition', () => {
 			}
 		});
 	});
+
+	it('should support dependencies', () => {
+		@openapi.definition({
+			title: 'Customer',
+			dependencies: {
+				c: ['a']
+			},
+			oneOf: [
+				{ required: ['a'] },
+				{ required: ['b'] }
+			]
+		})
+		class Customer {
+			@openapi.prop()
+			a?: string;
+
+			@openapi.prop()
+			b?: string;
+
+			@openapi.prop()
+			c?: string;
+		}
+
+		const definition = createSchemaDefinition(Customer);
+		should(definition).be.deepEqual({
+			Customer: {
+				title: 'Customer',
+				type: 'object',
+				properties: {
+					a: {
+						type: 'string'
+					},
+					b: {
+						type: 'string'
+					},
+					c: {
+						type: 'string'
+					}
+				},
+				dependencies: { c: ['a'] },
+				oneOf: [
+					{ required: ['a'] },
+					{ required: ['b'] }
+				]
+			}
+		});
+	});
 });


### PR DESCRIPTION
This will allow creating complicated validation rules using [dependencies](https://json-schema.org/understanding-json-schema/reference/object.html#dependencies).