### PR TITLE
fix: change errors type

### DIFF
--- a/packages/core/src/errors/httpErrors.ts
+++ b/packages/core/src/errors/httpErrors.ts
@@ -19,7 +19,7 @@ export class HttpError extends Error {
 
 	data: any;
 
-	errors: [any];
+	errors: any[];
 
 	_type = 'davinciHttpError'
 


### PR DESCRIPTION
`[any]` means a single element array while `any[]` means an array with any elements