### PR TITLE
fix: skip CI when committing to docs branch

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -21,5 +21,5 @@ cp -rf ./docs/.vuepress/dist/* ./
 rm -r ./docs
 
 git add .
-git commit --allow-empty -am "Update Docs"
+git commit --allow-empty -am "Update Docs [skip ci]"
 git push


### PR DESCRIPTION
The `gh-pages` branch has nothing to build/etc as it is only used for GitHub Pages content.

This PR simply adds `[skip ci]` to the commit made as part of the commit to that branch, which informs CircleCI that it doesn't need to do anything. 