### PR TITLE
feat: circleci matrix job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,21 @@
-version: 2
-jobs:
-  checkout_and_test:
+version: 2.1
+
+executors:
+  mongo3_6:
     docker:
       - image: circleci/node:10
       - image: circleci/mongo:3.6-jessie
+  mongo4_4:
+    docker:
+      - image: circleci/node:10
+      - image: circleci/mongo:4.4
+
+jobs:
+  checkout_and_test:
+    parameters:
+      mongo-version: 
+        type: executor
+    executor: << parameters.mongo-version >>
     steps:
       - checkout
 #      - restore_cache:
@@ -35,8 +47,7 @@ jobs:
       - save_cache:
           key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - ~
-
+            - ~/
   publish:
     docker:
       - image: circleci/node:8-stretch
@@ -74,7 +85,10 @@ workflows:
   version: 2
   build_and_publish:
     jobs:
-      - checkout_and_test
+      - checkout_and_test:
+          matrix:
+            parameters:
+              mongo-version: [mongo3_6, mongo4_4]
       - publish:
           requires:
             - checkout_and_test


### PR DESCRIPTION
Upgraded CircleCI configs to run **checkout_and_test** job to for both mongo 3.6 and mongo 4.4 versions. Use cached build from `mongo4_4` executor in `publish` and `publish_docs` jobs.

- [ ] Add two executors
- [ ] Update **save_cache** step

https://circleci.com/blog/circleci-matrix-jobs/