### PR TITLE
feat: circleci matrix job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,21 @@
-version: 2
-jobs:
-  checkout_and_test:
+version: 2.1
+
+executors:
+  mongo3_6:
     docker:
       - image: circleci/node:10
       - image: circleci/mongo:3.6-jessie
+  mongo4_4:
+    docker:
+      - image: circleci/node:10
+      - image: circleci/mongo:4.4
+
+jobs:
+  checkout_and_test:
+    parameters:
+      mongo-version: 
+        type: executor
+    executor: << parameters.mongo-version >>
     steps:
       - checkout
 #      - restore_cache:
@@ -33,16 +45,15 @@ jobs:
           command: |
             npx lerna run build
       - save_cache:
-          key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-source-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - ~
-
+            - ~/
   publish:
     docker:
       - image: circleci/node:8-stretch
     steps:
       - restore_cache:
-          key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-source-checkout_and_test-mongo4_4-{{ .Environment.CIRCLE_SHA1 }}
       - add_ssh_keys
       - run:
           name: Add github to known_hosts
@@ -62,7 +73,7 @@ jobs:
       - image: circleci/node:8-stretch
     steps:
       - restore_cache:
-          key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-source-checkout_and_test-mongo4_4-{{ .Environment.CIRCLE_SHA1 }}
       - add_ssh_keys
       - run:
           name: Deploy docs
@@ -74,7 +85,10 @@ workflows:
   version: 2
   build_and_publish:
     jobs:
-      - checkout_and_test
+      - checkout_and_test:
+          matrix:
+            parameters:
+              mongo-version: [mongo3_6, mongo4_4]
       - publish:
           requires:
             - checkout_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - save_cache:
           key: v1-source-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - ~/
+            - "~"
   publish:
     docker:
       - image: circleci/node:8-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,15 @@
 version: 2.1
 
-executors:
-  mongo3_6:
-    docker:
-      - image: circleci/node:10
-      - image: circleci/mongo:3.6-jessie
-  mongo4_4:
-    docker:
-      - image: circleci/node:10
-      - image: circleci/mongo:4.4
-
 jobs:
   checkout_and_test:
     parameters:
       mongo-version: 
-        type: executor
-    executor: << parameters.mongo-version >>
+        type: string
+      node-version: 
+        type: string
+    docker:
+      - image: circleci/node:<< parameters.node-version >>
+      - image: circleci/mongo:<< parameters.mongo-version >>
     steps:
       - checkout
 #      - restore_cache:
@@ -44,16 +38,22 @@ jobs:
           name: build
           command: |
             npx lerna run build
-      - save_cache:
-          key: v1-source-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - "~"
+      - when:
+          condition:
+            and:
+              - equal: [ "4.4", << parameters.mongo-version >> ]
+              - equal: [ "14", << parameters.node-version >> ]
+          steps:
+            - save_cache:
+                key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
+                paths:
+                  - "~"
   publish:
     docker:
       - image: circleci/node:8-stretch
     steps:
       - restore_cache:
-          key: v1-source-checkout_and_test-mongo4_4-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
       - add_ssh_keys
       - run:
           name: Add github to known_hosts
@@ -73,7 +73,7 @@ jobs:
       - image: circleci/node:8-stretch
     steps:
       - restore_cache:
-          key: v1-source-checkout_and_test-mongo4_4-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
       - add_ssh_keys
       - run:
           name: Deploy docs
@@ -88,7 +88,8 @@ workflows:
       - checkout_and_test:
           matrix:
             parameters:
-              mongo-version: [mongo3_6, mongo4_4]
+              mongo-version: ["3.6-jessie", "4.4"]
+              node-version: ["10", "12", "14"]
       - publish:
           requires:
             - checkout_and_test


### PR DESCRIPTION
Upgraded CircleCI configs to run **checkout_and_test** job to for both mongo 3.6 and mongo 4.4 versions. Use cached build from `mongo4_4` executor in `publish` and `publish_docs` jobs.

- [x] Add two executors
- [x] Update **save_cache** step

https://circleci.com/blog/circleci-matrix-jobs/