### PR TITLE
fix: switch to correct npm scope

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run:
           name: install NPM dependencies
           command: |
-            echo -e "//registry.npmjs.org/:_authToken=$NPM_TOKEN\nscope=@oneflow" > .npmrc
+            echo -e "//registry.npmjs.org/:_authToken=$NPM_TOKEN\nscope=@davinci" > .npmrc
             npm install
 #      - save_cache:
 #          key: v2-npm-deps-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@davinci/mongoose",
 	"version": "0.14.18",
-	"description": "> TODO: description",
+	"description": "Integration with Mongoose ODM",
 	"author": "HP",
 	"homepage": "",
 	"license": "ISC",


### PR DESCRIPTION
Switches from the legacy `@oneflow` scope to the correct `@davinci` scope when generating the `.npmrc` file in the CircleCI pipeline. 