### PR TITLE
fix: skip ci during publish commit

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,8 @@
 	"version": "independent",
 	"command": {
 		"publish": {
-			"conventionalCommits": true
+			"conventionalCommits": true,
+			"message": "chore(release): publish [skip ci]"
 		}
 	}
 }


### PR DESCRIPTION
During the CI/CD process, Lerna actually commits and pushes changes to the Git repo, bumping the version numbers in the package.json files and including the latest changes in the changelog file. 

These changes don't need to trigger a new build, so this PR adds `[skip ci]` to Lerna's "publish" commit message.