### PR TITLE
chore(openapi): 'prop' and 'definition' decorators now support root-level evel openapi props

### DIFF
--- a/examples/rest/src/api/customer/customer.schema.ts
+++ b/examples/rest/src/api/customer/customer.schema.ts
@@ -6,12 +6,13 @@ class CustomerPhone {
 	@mgoose.prop()
 	@openapi.prop()
 	number: string;
+
 	@mgoose.prop()
 	@openapi.prop()
 	isPrimary: boolean;
 }
 
-@openapi.definition({ title: 'BirtType' })
+@openapi.definition({ title: 'BirthType' })
 class BirthType {
 	@mgoose.prop()
 	@openapi.prop()
@@ -34,12 +35,25 @@ export default class Customer {
 	lastname: string;
 
 	@mgoose.prop()
-	@openapi.prop()
+	@openapi.prop({
+		minimum: 18
+	})
 	age: number;
 
 	@mgoose.prop()
-	@openapi.prop()
-	weight: number;
+	@openapi.prop({
+		type: null,
+		oneOf: [
+			{
+				type: 'number'
+			},
+			{
+				type: 'string',
+				pattern: '\\d+(kg|lbs)'
+			}
+		]
+	})
+	weight: number | string;
 
 	// typeFactory is useful in cases where schemas depends on each other (circular dependencies),
 	// because they will be evaluated lazily

--- a/packages/core/src/route/openapi/createSchemaDefinition.ts
+++ b/packages/core/src/route/openapi/createSchemaDefinition.ts
@@ -5,6 +5,7 @@
 
 import _fp from 'lodash/fp';
 import _merge from 'lodash/merge';
+import _omit from 'lodash/omit';
 import { Reflector } from '@davinci/reflector';
 import { ISwaggerDefinitions, IPropDecoratorMetadata } from '../types';
 
@@ -80,7 +81,7 @@ export const getSchemaDefinition = (theClass: Function, definitions = {}): ISwag
 
 				const schema = type ? makeSchema(type, k) : {};
 
-				acc[k] = opts?.rawSchemaOptions ? _merge({}, schema, opts.rawSchemaOptions) : schema;
+				acc[k] = _merge({}, schema, _omit(opts, ['type', 'required']), opts?.rawSchemaOptions);
 
 				return acc;
 			}, {});

--- a/packages/core/src/route/openapi/createSchemaDefinition.ts
+++ b/packages/core/src/route/openapi/createSchemaDefinition.ts
@@ -81,7 +81,12 @@ export const getSchemaDefinition = (theClass: Function, definitions = {}): ISwag
 
 				const schema = type ? makeSchema(type, k) : {};
 
-				acc[k] = _merge({}, schema, _omit(opts, ['type', 'required']), opts?.rawSchemaOptions);
+				acc[k] = _merge(
+					{},
+					schema,
+					_omit(opts, ['rawSchemaOptions', 'type', 'required']),
+					opts?.rawSchemaOptions
+				);
 
 				return acc;
 			}, {});

--- a/packages/core/src/route/types.ts
+++ b/packages/core/src/route/types.ts
@@ -85,16 +85,19 @@ type IDecoratorMetadata<T> = {
  * @param typeFactory - Function that returns a type (useful for lazily evaluated types)
  * @param required - Whether the property is required or not
  */
-export interface IPropDecoratorOptions {
+export interface IPropDecoratorOptions extends Omit<IJsonSchema, 'type' | 'required'> {
 	type?: TypeValue;
-	rawSchemaOptions?: unknown;
+	/**
+	 * @deprecated you can now pass Open API properties at the root configuration level
+	 */
+	rawSchemaOptions?: Omit<IJsonSchema, 'type' | 'required'>;
 	typeFactory?: TypeValueFactory;
 	required?: boolean;
 }
 export type IPropDecoratorOptionsFactory = IDecoratorOptionsFactory<IPropDecoratorOptions>;
 export type IPropDecoratorMetadata = IDecoratorMetadata<IPropDecoratorOptions>;
 
-export type IDefinitionDecoratorOptions = { title: any; } & Pick<IJsonSchema, 'dependencies' | 'oneOf' | 'allOf' | 'anyOf' | 'not'>;
+export type IDefinitionDecoratorOptions = { title: any; } & Omit<IJsonSchema, 'type' | 'required'>;
 
 export interface IMethodResponseOutput {
 	description?: string;

--- a/packages/core/test/unit/route/decorators/openapi.test.ts
+++ b/packages/core/test/unit/route/decorators/openapi.test.ts
@@ -19,6 +19,37 @@ describe('openapi decorators', () => {
 
 			should(propsMetadata[0].optsFactory()).match({ required: false });
 		});
+
+		it('should support openapi properties at the root level', () => {
+			class Customer {
+				@openapi.prop({
+					required: false,
+					oneOf: [{ type: 'string', enum: ['one', 'two'] }, { type: 'number' }]
+				})
+				firstname: string;
+			}
+
+			const propsMetadata = Reflect.getMetadata('davinci:openapi:props', Customer);
+			should(propsMetadata[0])
+				.have.property('key')
+				.equal('firstname');
+			should(propsMetadata[0])
+				.have.property('optsFactory')
+				.type('function');
+
+			should(propsMetadata[0].optsFactory()).match({
+				required: false,
+				oneOf: [
+					{
+						type: 'string',
+						enum: ['one', 'two']
+					},
+					{
+						type: 'number'
+					}
+				]
+			});
+		});
 	});
 
 	describe('@openapi.definition()', () => {

--- a/packages/core/test/unit/route/openapi/createSchemaDefinition.test.ts
+++ b/packages/core/test/unit/route/openapi/createSchemaDefinition.test.ts
@@ -293,7 +293,7 @@ describe('createSchemaDefinition', () => {
 		});
 	});
 
-	it('combines schema from `rawSchemaOptions` argument and the one generated from `type` argument ', () => {
+	it('combines schema from `rawSchemaOptions` argument and the one generated from `type` argument', () => {
 		@openapi.definition({ title: 'ScanPayloadArrayItem' })
 		class ScanPayloadArrayItem {
 			@openapi.prop({ required: true })

--- a/packages/mongoose/src/createMongooseController.ts
+++ b/packages/mongoose/src/createMongooseController.ts
@@ -61,17 +61,15 @@ export const createMongooseController = <T extends Constructor<{}>>(Model, Resou
 		$where?: object;
 
 		@openapi.prop({
-			rawSchemaOptions: {
-				oneOf: [
-					{
-						type: 'object'
-					},
-					{
-						type: 'array',
-						items: { type: 'string' }
-					}
-				]
-			}
+			oneOf: [
+				{
+					type: 'object'
+				},
+				{
+					type: 'array',
+					items: { type: 'string' }
+				}
+			]
 		})
 		$select?: object | string[];
 
@@ -98,17 +96,15 @@ export const createMongooseController = <T extends Constructor<{}>>(Model, Resou
 
 		@openapi.prop({
 			type: null,
-			rawSchemaOptions: {
-				oneOf: [
-					{
-						type: 'object'
-					},
-					{
-						type: 'array',
-						items: { type: 'string' }
-					}
-				]
-			}
+			oneOf: [
+				{
+					type: 'object'
+				},
+				{
+					type: 'array',
+					items: { type: 'string' }
+				}
+			]
 		})
 		$select?: object | string[];
 


### PR DESCRIPTION
Previously the openapi options they had to be passed inside  a 'rawSchemaOptions' property.
With the changes contained in the PR the openapi options can be passed a the root level

### Example

#### Before
![Screenshot 2021-01-26 at 11 24 30](https://user-images.githubusercontent.com/2676481/105839237-19bfd680-5fc9-11eb-9815-6f04583522bd.png)

#### After
![Screenshot 2021-01-26 at 11 24 38](https://user-images.githubusercontent.com/2676481/105839456-6d322480-5fc9-11eb-89b6-400c8895d062.png)

