### PR TITLE
docs: update mongoose hooks documentation

### DIFF
--- a/docs/guide/database/mongoose.md
+++ b/docs/guide/database/mongoose.md
@@ -103,7 +103,6 @@ Under the hood, they use [Mongoose Middlewares](https://mongoosejs.com/docs/midd
     Under the hood it register the following Mongoose Middlewares:
     `findOneAndUpdate`,
     `save`,
-    `validate`,
     `update`,
     `updateMany`
 -   **beforeDelete / afterDelete**\


### PR DESCRIPTION
Updated documentation for mongoose hooks.

**Validate** middleware for afterWrite/beforeWrite hooks is not supported [(the list of supported middlewares)](https://github.com/HPInc/davinci/blob/master/packages/mongoose/src/hooks.ts#L19)