### PR TITLE
feat(openapi): expose function to generate openapi definitions

### DIFF
--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -16,7 +16,7 @@ import { DaVinciRequest, IHeaderDecoratorMetadata } from '../express/types';
 import { NotImplemented, BadRequest } from '../errors/httpErrors';
 import * as openapiDocs from './openapi/openapiDocs';
 import createPaths from './openapi/createPaths';
-import createSchemaDefinition from './openapi/createSchemaDefinition';
+import createOpenapiSchemaDefinitions from './openapi/createOpenapiSchemaDefinitions';
 import { IControllerDecoratorArgs } from './decorators/route';
 import { ISchema, ISwaggerDefinitions, MethodValidation, PathsValidationOptions } from './types';
 import { DaVinciExpress } from '../index';
@@ -339,10 +339,10 @@ const createRouterAndSwaggerDoc = (
 	const controller = new Controller();
 
 	// create the swagger structure
-	const mainDefinition = resourceSchema ? createSchemaDefinition(resourceSchema) : {};
+	const mainDefinition = resourceSchema ? createOpenapiSchemaDefinitions(resourceSchema) : {};
 	const additionalDefinitions = _.reduce(
 		additionalSchemas,
-		(acc, schema) => ({ ...acc, ...createSchemaDefinition(schema) }),
+		(acc, schema) => ({ ...acc, ...createOpenapiSchemaDefinitions(schema) }),
 		[]
 	);
 
@@ -366,7 +366,7 @@ const createRouterAndSwaggerDoc = (
 		return router[route.method](routePath, ...route.handlers);
 	});
 
-	openapiDocs.addResource(resourceName, definition, basepath);
+	openapiDocs.addResource(definition, resourceName, basepath);
 
 	return router;
 };

--- a/packages/core/src/route/decorators/openapi.ts
+++ b/packages/core/src/route/decorators/openapi.ts
@@ -38,6 +38,6 @@ export function prop<T = any>(opts?: IPropDecoratorOptions<T> | IPropDecoratorOp
  */
 export function definition<T = any>(options?: IDefinitionDecoratorOptions<T>) {
 	return function(target: Function): void {
-		Reflector.defineMetadata('davinci:openapi:definition', options, target);
+		Reflector.defineMetadata('davinci:openapi:definition', options ?? {}, target);
 	};
 }

--- a/packages/core/src/route/index.ts
+++ b/packages/core/src/route/index.ts
@@ -6,6 +6,7 @@
 import * as route from './decorators/route';
 import * as openapi from './decorators/openapi';
 import * as openapiDocs from './openapi/openapiDocs';
-import createRouter from './createRouter';
 
-export { route, openapi, openapiDocs, createRouter };
+export { route, openapi, openapiDocs };
+export { default as createRouter } from './createRouter';
+export { createOpenapiSchemaDefinitions } from './openapi/createOpenapiSchemaDefinitions';

--- a/packages/core/src/route/openapi/Resource.ts
+++ b/packages/core/src/route/openapi/Resource.ts
@@ -17,7 +17,7 @@ class Resource {
 
 	basePath: string;
 
-	constructor(resourceName, doc, basePath?) {
+	constructor(doc, resourceName, basePath?) {
 		this.resourceName = resourceName;
 		this.paths = doc.paths;
 		this.definitions = doc.definitions;

--- a/packages/core/src/route/openapi/createOpenapiSchemaDefinitions.ts
+++ b/packages/core/src/route/openapi/createOpenapiSchemaDefinitions.ts
@@ -9,7 +9,7 @@ import _omit from 'lodash/omit';
 import { Reflector } from '@davinci/reflector';
 import { ISwaggerDefinitions, IPropDecoratorMetadata } from '../types';
 
-export const getSchemaDefinition = (theClass: Function, definitions = {}): ISwaggerDefinitions => {
+export const getOpenapiSchemaDefinitions = (theClass: Function, definitions = {}): ISwaggerDefinitions => {
 	const makeSchema = (typeOrClass, key?) => {
 		// it's a primitive type, simple case
 		if ([String, Number, Boolean, Date].includes(typeOrClass)) {
@@ -49,7 +49,7 @@ export const getSchemaDefinition = (theClass: Function, definitions = {}): ISwag
 				type: 'object'
 			};
 
-			const title: string = hasDefinitionDecoration ? definitionMetadata.title : key || typeOrClass.name;
+			const title: string = definitionMetadata?.title ?? key ?? typeOrClass.name;
 			if (hasDefinitionDecoration) {
 				if (definitions[title]) {
 					return {
@@ -125,12 +125,12 @@ export const getSchemaDefinition = (theClass: Function, definitions = {}): ISwag
 	return { schema, definitions };
 };
 
-export const createSchemaDefinition = (theClass: Function) => {
+export const createOpenapiSchemaDefinitions = (theClass: Function) => {
 	if (theClass) {
-		const { definitions } = getSchemaDefinition(theClass);
+		const { definitions } = getOpenapiSchemaDefinitions(theClass);
 		return definitions;
 	}
 	return {};
 };
 
-export default createSchemaDefinition;
+export default createOpenapiSchemaDefinitions;

--- a/packages/core/src/route/openapi/createPaths.ts
+++ b/packages/core/src/route/openapi/createPaths.ts
@@ -8,7 +8,7 @@ import _fp from 'lodash/fp';
 import { Reflector } from '@davinci/reflector';
 import { PathsDefinition, PathsValidationOptions, ISwaggerDefinitions, IMethodDecoratorMetadata } from '../types';
 import { IControllerDecoratorArgs } from '../decorators/route';
-import { getSchemaDefinition } from './createSchemaDefinition';
+import { getOpenapiSchemaDefinitions } from './createOpenapiSchemaDefinitions';
 
 const getParameterDefinition = methodParameterConfig => {
 	const { type,  options: { type: t = null, enum: enumOptions = null, ...options } = {} } = methodParameterConfig;
@@ -26,7 +26,7 @@ const getParameterDefinition = methodParameterConfig => {
 		} else if (enumOptions?.length) {
 			const { schemas, definitions } = enumOptions.reduce(
 				(acc, enumType) => {
-					const { schema: s, definitions: d } = getSchemaDefinition(enumType);
+					const { schema: s, definitions: d } = getOpenapiSchemaDefinitions(enumType);
 					acc.schemas.push(s);
 					acc.definitions = { ...acc.definitions, ...d };
 					return acc;
@@ -41,7 +41,7 @@ const getParameterDefinition = methodParameterConfig => {
 
 			return { paramDefinition, definitions };
 		} else {
-			const { schema: s, definitions } = getSchemaDefinition(type);
+			const { schema: s, definitions } = getOpenapiSchemaDefinitions(type);
 			paramDefinition.schema = s;
 
 			return { paramDefinition, definitions };
@@ -87,7 +87,7 @@ const createPathsDefinition = (
 			const resps = responses
 				? _.mapValues(responses, response => {
 					if (typeof response === 'function') {
-						const { definitions: defs, schema } = getSchemaDefinition(response);
+						const { definitions: defs, schema } = getOpenapiSchemaDefinitions(response);
 						acc.definitions = { ...acc.definitions, ...defs };
 						return { schema };
 					}

--- a/packages/core/src/route/openapi/openapiDocs.ts
+++ b/packages/core/src/route/openapi/openapiDocs.ts
@@ -13,10 +13,10 @@ const SWAGGER_VERSION = '2.0';
 
 export const resources = [];
 
-export const addResource = (resourceName, doc, basepath?) => {
-	debug(`adding ${resourceName} resource`);
+export const addResource = (doc, resourceName?: string, basepath?: string) => {
+	debug(`adding resource`, resourceName);
 	// create the resource from the doc
-	const resource = new Resource(resourceName, doc, basepath);
+	const resource = new Resource(doc, resourceName, basepath);
 	// add it to the registry
 	resources.push(resource);
 };

--- a/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
+++ b/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
@@ -1,8 +1,9 @@
 import should from 'should';
-import createSchemaDefinition from '../../../../src/route/openapi/createSchemaDefinition';
+import createOpenapiSchemaDefinitions from '../../../../src/route/openapi/createOpenapiSchemaDefinitions';
 import { openapi } from '../../../../src/route';
+import * as openapiDocs from '../../../../src/route/openapi/openapiDocs';
 
-describe('createSchemaDefinition', () => {
+describe('createOpenapiSchemaDefinitions', () => {
 	it('Given a decorated class, it should create a schema definition', () => {
 		@openapi.definition({ title: 'Customer' })
 		class Customer {
@@ -12,7 +13,7 @@ describe('createSchemaDefinition', () => {
 			lastname: string;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -43,7 +44,7 @@ describe('createSchemaDefinition', () => {
 			phone: CustomerPhone;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -82,7 +83,7 @@ describe('createSchemaDefinition', () => {
 			phone: CustomerPhone;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			CustomerPhone: {
 				title: 'CustomerPhone',
@@ -115,7 +116,7 @@ describe('createSchemaDefinition', () => {
 			groups: string[];
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -146,7 +147,7 @@ describe('createSchemaDefinition', () => {
 			phone: CustomerPhone[];
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -207,7 +208,7 @@ describe('createSchemaDefinition', () => {
 		 *  };
 		 */
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			CustomerPhone: {
 				title: 'CustomerPhone',
@@ -245,7 +246,7 @@ describe('createSchemaDefinition', () => {
 			lastname: string;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -270,7 +271,7 @@ describe('createSchemaDefinition', () => {
 			customData: string;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -318,7 +319,7 @@ describe('createSchemaDefinition', () => {
 			scans: ScanPayloadArrayItem[];
 		}
 
-		const definition = createSchemaDefinition(ScanPayload);
+		const definition = createOpenapiSchemaDefinitions(ScanPayload);
 		should(definition).be.deepEqual({
 			ScanPayload: {
 				title: 'ScanPayload',
@@ -369,7 +370,7 @@ describe('createSchemaDefinition', () => {
 			someProp: object | string[];
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -410,7 +411,7 @@ describe('createSchemaDefinition', () => {
 			c?: string;
 		}
 
-		const definition = createSchemaDefinition(Customer);
+		const definition = createOpenapiSchemaDefinitions(Customer);
 		should(definition).be.deepEqual({
 			Customer: {
 				title: 'Customer',
@@ -429,6 +430,48 @@ describe('createSchemaDefinition', () => {
 				dependencies: { c: ['a'] },
 				oneOf: [{ required: ['a'] }, { required: ['b'] }]
 			}
+		});
+	});
+
+	it('should be able to generate an Open API definition and add it to the openapiDocs', () => {
+		@openapi.definition()
+		class Customer {
+			@openapi.prop()
+			firstname: string;
+
+			@openapi.prop({ required: true })
+			lastname: string;
+		}
+
+		const definitions = createOpenapiSchemaDefinitions(Customer);
+		openapiDocs.addResource({ definitions });
+		const swagger = openapiDocs.generateFullSwagger({
+			basePath: '/api',
+			info: { version: '1.0.0', title: 'API' }
+		});
+
+		should(swagger).be.match({
+			swagger: '2.0',
+			info: {
+				version: '1.0.0',
+				title: 'API'
+			},
+			definitions: {
+				Customer: {
+					type: 'object',
+					title: 'Customer',
+					properties: {
+						firstname: {
+							type: 'string'
+						},
+						lastname: {
+							type: 'string'
+						}
+					},
+					required: ['lastname']
+				}
+			},
+			parameters: {}
 		});
 	});
 });

--- a/packages/core/test/unit/route/openapi/openapiDocs.test.ts
+++ b/packages/core/test/unit/route/openapi/openapiDocs.test.ts
@@ -44,23 +44,26 @@ describe('openapiDocs', () => {
 
 	describe('#generateFullSwagger', () => {
 		it('should generate a swagger doc', () => {
-			openapiDocs.addResource('customer', {
-				definitions: { Customer: { type: 'object' } },
-				paths: {
-					'/': {
-						get: {
-							summary: 'This is a summary',
-							operationId: 'operationId',
-							parameters: [{ name: 'query', in: 'query', schema: { type: 'string' } }],
-							responses: {
-								'200': {
-									description: 'Result'
+			openapiDocs.addResource(
+				{
+					definitions: { Customer: { type: 'object' } },
+					paths: {
+						'/': {
+							get: {
+								summary: 'This is a summary',
+								operationId: 'operationId',
+								parameters: [{ name: 'query', in: 'query', schema: { type: 'string' } }],
+								responses: {
+									'200': {
+										description: 'Result'
+									}
 								}
 							}
 						}
 					}
-				}
-			});
+				},
+				'customer'
+			);
 			const swagger = openapiDocs.generateFullSwagger({
 				basePath: '/api',
 				info: { version: '1.0.0', title: 'API' }
@@ -106,29 +109,32 @@ describe('openapiDocs', () => {
 		});
 
 		it('should strip out req, res, context parameters from paths', () => {
-			openapiDocs.addResource('customer', {
-				definitions: { Customer: { type: 'object' } },
-				paths: {
-					'/': {
-						get: {
-							summary: 'This is a summary',
-							operationId: 'operationId',
-							parameters: [
-								{ name: 'theQuery', in: 'query', schema: { type: 'string' } },
-								{ schema: { type: 'context' } },
-								{ schema: { type: 'req' } },
-								{ schema: { type: 'res' } },
-								{ name: 'theBody', in: 'body', schema: { type: 'object' } }
-							],
-							responses: {
-								'200': {
-									description: 'Result'
+			openapiDocs.addResource(
+				{
+					definitions: { Customer: { type: 'object' } },
+					paths: {
+						'/': {
+							get: {
+								summary: 'This is a summary',
+								operationId: 'operationId',
+								parameters: [
+									{ name: 'theQuery', in: 'query', schema: { type: 'string' } },
+									{ schema: { type: 'context' } },
+									{ schema: { type: 'req' } },
+									{ schema: { type: 'res' } },
+									{ name: 'theBody', in: 'body', schema: { type: 'object' } }
+								],
+								responses: {
+									'200': {
+										description: 'Result'
+									}
 								}
 							}
 						}
 					}
-				}
-			});
+				},
+				'customer'
+			);
 			const swagger = openapiDocs.generateFullSwagger({
 				basePath: '/api',
 				info: { version: '1.0.0', title: 'API' }


### PR DESCRIPTION
## Motivation
There are situations where it may be preferable to manually create OpenAPI definitions and add them to the OpenAPI Document.

### Example
```ts
@openapi.definition()
export class PaginationQuery {
	@openapi.prop({ 
             type: null, 
             oneOf: [{ $ref: '#/definitions/PopulateQuery' }, { type: 'string' }] 
        })
	$populate?: PopulateQuery | string;
}
```
In this example, we want to be able to define the type of the **$populate** property to be either `PopulateQuery` or `string`.
But the class reflection and traversal won't be executed because `type` is set to `null` to allow the advanced use of `oneOf`, so the `PopulateQuery` definition is not tracked and won't be added in the OpenAPI document.

The changes in this PR allow to manually add a definition to the OpenAPI main document:
```ts
import { openapiDocs, createOpenapiSchemaDefinitions } from '@davinci/core';

const additionalDefinitions = createOpenapiSchemaDefinitions(PopulateQuery);
openapiDocs.addResource({ definitions: additionalDefinitions }); // manually adding the PopulateQuery definition

@openapi.definition()
export class PaginationQuery {
	@openapi.prop({ 
             type: null, 
             oneOf: [{ $ref: '#/definitions/PopulateQuery' }, { type: 'string' }] 
        })
	$populate?: PopulateQuery | string;
}
```

## Other changes
- refactored openapiDocs.addResource signature
- fixed tests

### Future improvements
In the future we may want to enable the traversal and reflection also on the advanced OpenAPI properties  like `oneOf` or `anyOf`, so that the definition would be as simple as: 
```ts
@openapi.definition()
export class PaginationQuery {
	@openapi.prop({ 
             oneOf: [PopulateQuery, { type: 'string' }] 
        })
	$populate?: PopulateQuery | string;
}
```