### PR TITLE
fix: use correct 'debug' namespace

### DIFF
--- a/packages/core/src/express/boot/index.ts
+++ b/packages/core/src/express/boot/index.ts
@@ -12,7 +12,7 @@ import fsModule from 'fs';
 
 const fs = Promise.promisifyAll(fsModule);
 
-const debug = new Debug('of-base-api');
+const debug = new Debug('davinci:boot');
 
 export const checkAndAssignBootDir = options => {
 	// create an array of boot paths


### PR DESCRIPTION
This PR fixes a leftover `debug` namespace from the original `of-base-api` library.

No API functionality has changed with this PR, just the namespace used when outputting logs.