### PR TITLE
Fix: pass ajv instance on json parsing

### DIFF
--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -104,15 +104,15 @@ const attemptJsonParsing = ({ value, config, definitions, validationOptions, ajv
 			return {
 				value: JSON.parse(value),
 				config,
-
-				definitions
+				definitions,
+				ajv
 			};
 		} catch (err) {
 			return {
 				value,
 				config,
-
-				definitions
+				definitions,
+				ajv
 			};
 		}
 	}


### PR DESCRIPTION
* Fix: pass through ajv instance when performing json parsing.