### PR TITLE
Fix: Pass current parameter to ajv factory

### DIFF
--- a/examples/rest-custom-ajv/src/index.ts
+++ b/examples/rest-custom-ajv/src/index.ts
@@ -42,11 +42,11 @@ const expressApp: Express = express();
 
 const contextFactory = ({ req }): Context => ({ accountId: req.headers['x-custom-accountid'] });
 
-const ajvFactory = (section: string) => {
-	const coerceIn: string[] = ['header', 'query'];
+const ajvFactory = ({ parameter }) => {
+	const coerceTypesIn: string[] = ['header', 'query'];
 	const ajv = new Ajv({
 		allErrors: true,
-		coerceTypes: coerceIn.includes(section),
+		coerceTypes: coerceTypesIn.includes(parameter.in),
 		useDefaults: true,
 		removeAdditional: 'all'
 	});

--- a/examples/rest-custom-ajv/src/index.ts
+++ b/examples/rest-custom-ajv/src/index.ts
@@ -42,10 +42,11 @@ const expressApp: Express = express();
 
 const contextFactory = ({ req }): Context => ({ accountId: req.headers['x-custom-accountid'] });
 
-const ajvFactory = () => {
+const ajvFactory = (section: string) => {
+	const coerceIn: string[] = ['header', 'query'];
 	const ajv = new Ajv({
 		allErrors: true,
-		coerceTypes: false,
+		coerceTypes: coerceIn.includes(section),
 		useDefaults: true,
 		removeAdditional: 'all'
 	});

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -157,8 +157,8 @@ type ContextFactory<ContextReturnType = any> = ({
 
 const defaultContextFactory: ContextFactory = ({ req, res }) => ({ req, res });
 
-type AjvFactoryParameters = { parameter };
-type AjvFactory = (parameters: AjvFactoryParameters) => Ajv;
+export type AjvFactoryParameters = { parameter };
+export type AjvFactory = (parameters: AjvFactoryParameters) => Ajv;
 
 const createDefaultAjvInstance: AjvFactory = () => {
 	const ajv = new Ajv({
@@ -358,7 +358,7 @@ function processParameters(params: [CreateRouterParameters] | CreateRouterParame
 	};
 }
 
-type CreateRouterParameters = {
+export type CreateRouterParameters = {
 	Controller: ClassType;
 	resourceName?: string | null;
 	contextFactory?: ContextFactory | null;
@@ -373,7 +373,7 @@ type CreateRouterParametersArray = [
 	Router | undefined
 ];
 
-function createRouterAndSwaggerDoc(Controller: CreateRouterParameters): Router | DaVinciExpress;
+function createRouterAndSwaggerDoc(parameters: CreateRouterParameters): Router | DaVinciExpress;
 /**
  * The base class for controls that can be rendered.
  *

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -157,7 +157,7 @@ type ContextFactory<ContextReturnType = any> = ({
 
 const defaultContextFactory: ContextFactory = ({ req, res }) => ({ req, res });
 
-type AjvFactory = () => Ajv;
+type AjvFactory = (section?: string) => Ajv;
 
 const createDefaultAjvInstance: AjvFactory = () => {
 	const ajv = new Ajv({
@@ -208,7 +208,7 @@ function mapReqToParameters<ContextType>(
 				config: p,
 				definitions,
 				validationOptions: methodValidationOptions,
-				ajv: ajv()
+				ajv: ajv(p.in)
 			});
 		}
 		return acc;

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -157,7 +157,7 @@ type ContextFactory<ContextReturnType = any> = ({
 
 const defaultContextFactory: ContextFactory = ({ req, res }) => ({ req, res });
 
-type AjvFactory = (section?: string) => Ajv;
+type AjvFactory = (section: string) => Ajv;
 
 const createDefaultAjvInstance: AjvFactory = () => {
 	const ajv = new Ajv({

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -157,7 +157,8 @@ type ContextFactory<ContextReturnType = any> = ({
 
 const defaultContextFactory: ContextFactory = ({ req, res }) => ({ req, res });
 
-type AjvFactory = (section: string) => Ajv;
+type AjvFactoryParameters = { parameter };
+type AjvFactory = (parameters: AjvFactoryParameters) => Ajv;
 
 const createDefaultAjvInstance: AjvFactory = () => {
 	const ajv = new Ajv({
@@ -208,7 +209,7 @@ function mapReqToParameters<ContextType>(
 				config: p,
 				definitions,
 				validationOptions: methodValidationOptions,
-				ajv: ajv(p.in)
+				ajv: ajv({ parameter: p })
 			});
 		}
 		return acc;


### PR DESCRIPTION
* Pass current parameter to ajv factory method so that client is able to choose whether or not to enable some features.
* Updated examples.