### PR TITLE
feat: added type-safe OpenAPI 3 doc generation

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -4,14 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
 		"@godaddy/terminus": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.6.0.tgz",
@@ -390,6 +382,11 @@
 				"ee-first": "1.1.1"
 			}
 		},
+		"openapi-types": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.0.3.tgz",
+			"integrity": "sha512-c4C1xAKZOvOxeSWvRY0d2XsoaZoF8M7rifxfZZCIH2mqPEQxOz8qfFx4oEpLFaE+DfDGe08HcIA/p1Bu93keLQ=="
+		},
 		"parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -440,11 +437,6 @@
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			}
-		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
 		},
 		"require-dir": {
 			"version": "1.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
 		"bluebird": "^3.5.0",
 		"debug": "^4.1.1",
 		"lodash": "^4.17.19",
+		"openapi-types": "^9.0.3",
 		"require-dir": "^1.2.0"
 	},
 	"peerDependencies": {

--- a/packages/core/src/createApp.ts
+++ b/packages/core/src/createApp.ts
@@ -84,15 +84,15 @@ export const configureExpress = async (app, options: DaVinciOptions = {}, runMid
 	// swaggern
 	const { path: openapiDocsPath, options: openapiDocsOpts } = options?.openapi?.docs || {};
 	if (openapiDocsPath) {
-		const fullSwaggerDoc = docs.generateFullSwagger(openapiDocsOpts);
+		const fullOpenAPIDoc = docs.generateOpenAPIv3(openapiDocsOpts);
 		// tslint:disable-next-line:variable-name
-		app.get(openapiDocsPath, (_req, res) => res.json(fullSwaggerDoc));
+		app.get(openapiDocsPath, (_req, res) => res.json(fullOpenAPIDoc));
 
 		const { path: swaggerUIPath, options: swaggerUIOpts } = options?.openapi?.ui || {};
 		if (swaggerUIPath) {
 			// eslint-disable-next-line
 			const swaggerUi = require('swagger-ui-express');
-			app.use(swaggerUIPath, swaggerUi.serve, swaggerUi.setup(fullSwaggerDoc, swaggerUIOpts));
+			app.use(swaggerUIPath, swaggerUi.serve, swaggerUi.setup(fullOpenAPIDoc, swaggerUIOpts));
 			console.log(`--- Swagger UI available at ${swaggerUIPath}`);
 		}
 	}

--- a/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
+++ b/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
@@ -445,8 +445,7 @@ describe('createOpenapiSchemaDefinitions', () => {
 
 		const definitions = createOpenapiSchemaDefinitions(Customer);
 		openapiDocs.addResource({ definitions });
-		const swagger = openapiDocs.generateFullSwagger({
-			basePath: '/api',
+		const swagger = openapiDocs.generateOpenAPIv3({
 			info: { version: '1.0.0', title: 'API' }
 		});
 

--- a/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
+++ b/packages/core/test/unit/route/openapi/createOpenapiSchemaDefinitions.test.ts
@@ -450,27 +450,28 @@ describe('createOpenapiSchemaDefinitions', () => {
 		});
 
 		should(swagger).be.match({
-			swagger: '2.0',
+			openapi: '3.0.3',
 			info: {
 				version: '1.0.0',
 				title: 'API'
 			},
-			definitions: {
-				Customer: {
-					type: 'object',
-					title: 'Customer',
-					properties: {
-						firstname: {
-							type: 'string'
+			components: {
+				schemas: {
+					Customer: {
+						type: 'object',
+						title: 'Customer',
+						properties: {
+							firstname: {
+								type: 'string'
+							},
+							lastname: {
+								type: 'string'
+							}
 						},
-						lastname: {
-							type: 'string'
-						}
-					},
-					required: ['lastname']
+						required: ['lastname']
+					}
 				}
-			},
-			parameters: {}
+			}
 		});
 	});
 });

--- a/packages/core/test/unit/route/openapi/openapiDocs.test.ts
+++ b/packages/core/test/unit/route/openapi/openapiDocs.test.ts
@@ -8,42 +8,16 @@ describe('openapiDocs', () => {
 	});
 
 	it('should add a resource using a swagger document', () => {
-		openapiDocs.generateFullSwagger({
-			discoveryUrl: '/api-doc.json',
-			version: '1.0', // read from package.json
-			basePath: '/api'
+		openapiDocs.generateOpenAPIv3({
+			info: {
+				title: 'API',
+				version: '1.0'
+			}
 		});
 	});
 
-	it('should add a resource using a swagger document', () => {
-		openapiDocs.generateFullSwagger({
-			discoveryUrl: '/api-doc.json',
-			version: '1.0', // read from package.json
-			basePath: '/api',
-			protocol: 'https'
-		});
-	});
-
-	it('should add a resource using a swagger document', () => {
-		openapiDocs.generateFullSwagger({
-			discoveryUrl: '/api-doc.json',
-			version: '1.0', // read from package.json
-			basePath: '/api',
-			protocol: 'http'
-		});
-	});
-
-	it('should add a resource using a swagger document', () => {
-		openapiDocs.generateFullSwagger({
-			discoveryUrl: '/api-doc.json',
-			version: '1.0', // read from package.json
-			basePath: null,
-			protocol: 'https'
-		});
-	});
-
-	describe('#generateFullSwagger', () => {
-		it('should generate a swagger doc', () => {
+	describe('#generateOpenAPIv3', () => {
+		it('should generate an OpenAPI doc', () => {
 			openapiDocs.addResource(
 				{
 					definitions: { Customer: { type: 'object' } },
@@ -64,12 +38,11 @@ describe('openapiDocs', () => {
 				},
 				'customer'
 			);
-			const swagger = openapiDocs.generateFullSwagger({
-				basePath: '/api',
+			const swagger = openapiDocs.generateOpenAPIv3({
 				info: { version: '1.0.0', title: 'API' }
 			});
 			should(swagger).be.match({
-				swagger: '2.0',
+				openapi: '3.0.3',
 				info: {
 					version: '1.0.0',
 					title: 'API'
@@ -99,12 +72,13 @@ describe('openapiDocs', () => {
 						}
 					}
 				},
-				definitions: {
-					Customer: {
-						type: 'object'
+				components: {
+					schemas: {
+						Customer: {
+							type: 'object'
+						}
 					}
-				},
-				parameters: {}
+				}
 			});
 		});
 
@@ -135,8 +109,7 @@ describe('openapiDocs', () => {
 				},
 				'customer'
 			);
-			const swagger = openapiDocs.generateFullSwagger({
-				basePath: '/api',
+			const swagger = openapiDocs.generateOpenAPIv3({
 				info: { version: '1.0.0', title: 'API' }
 			});
 			should(swagger.paths['/customer'].get.parameters).have.length(2);
@@ -189,8 +162,7 @@ describe('openapiDocs', () => {
 				},
 				'customer'
 			);
-			const swagger = openapiDocs.generateFullSwagger({
-				basePath: '/api',
+			const swagger = openapiDocs.generateOpenAPIv3({
 				info: { version: '1.0.0', title: 'API' }
 			});
 
@@ -241,12 +213,11 @@ describe('openapiDocs', () => {
 				},
 				'customer'
 			);
-			const swagger = openapiDocs.generateFullSwagger({
-				basePath: '/api',
+			const swagger = openapiDocs.generateOpenAPIv3({
 				info: { version: '1.0.0', title: 'API' }
 			});
 
-			should(swagger.definitions).be.deepEqual({
+			should(swagger.components.schemas).be.deepEqual({
 				Animal: {
 					type: 'object'
 				},


### PR DESCRIPTION
_NOTE: This PR is intended to be an RFC more than a complete & ready code change!_

## Overview

This PR proposes an option to update Da Vinci from Swagger/OpenAPIv2 to OpenAPIv3 as well as introducing type-safety into the OpenAPI doc generation code. It leverages an open-source package called [`openapi-types`](https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-types) to achieve the type-safety, which also improves the developer experience when configuring the docs for new APIs.

## Still To Do 

### basePath vs [`servers`](https://swagger.io/docs/specification/api-host-and-base-path/)

The `basePath` property was removed but I've not yet implemented the necessary code to recreate this with OpenAPIv3. This is because OpenAPIv3 now specifies a list of servers, meaning the API will need to have some knowledge about where it is deployed (FQDN) and that server URL will include the basePath. 

### Swagger UI

According to [this issue](https://github.com/scottie1984/swagger-ui-express/issues/96#issuecomment-425830983), Swagger UI should have no problem supporting OpenAPI v3. All that's left is to test + confirm.

### Tidy Up

We should replace any usages of the term `Swagger` to `OpenAPI` since the specification has officially been renamed. 

Also, some of the existing Da Vinci methods are written with the assumption that the Swagger docs have a `definitions` object (for example, [getOpenapiSchemaDefinitions ](https://github.com/HPInc/davinci/blob/master/packages/core/src/route/openapi/createOpenapiSchemaDefinitions.ts#L12)). These should be updated to more closely match the new OpenAPI v3 schema.

### Manual validation

We should throw this into a reasonably complex Da Vinci-based API and grab the generated OpenAPI docs, then chuck it into a third party OpenAPI validator to see if there are any other inconsistencies we've missed. 


## Breaking Changes to APIs

Since we're upgrading from Swagger/OpenAPIv2 to OpenAPIv3, there are breaking changes. I've noticed a couple and mentioned them below, but there may be more. 


### basePath

This is no longer supported by OpenAPIv3. So you'll need to remove this from your Da Vinci initialisation code. 

```JavaScript
// Remove this line:
    basePath: config.openapi.basePath,
// Replace with:
//    TBC!
```

### info.name

This has been incorrect for a long time (see PR #32) but now TypeScript will complain. 

```JavaScript
// Change:
info: { name: 'my api', version: '1.2.3' }

// To:
info: { title: 'my api', version: '1.2.3' }
```

### securityDefinitions

This is essentially the same structure, but has been renamed and relocated into the `components` property:

```JavaScript
// Change:
securityDefinitions: { Bearer: { type: 'apiKey', name: 'Authorization', in: 'header' } },

// To:
components: {
    securitySchemes: { Bearer: { type: 'apiKey', name: 'Authorization', in: 'header' } }
}
```
