### PR TITLE
Update to newest TypeScript dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,10 +64,10 @@
 
 		"@typescript-eslint/interface-name-prefix": 0,
 
-		"@typescript-eslint/ban-ts-comment": 1,
+		// discourage the use of @ts-ignore to hide TypeScript warnings/errors
+		"@typescript-eslint/ban-ts-comment": [1, { "ts-ignore": true }],
 
-		"@typescript-eslint/no-empty-function": 0,
-
+		// disable banning of specific types used in the codebase
 		"@typescript-eslint/ban-types": [2, {
 			"types": {
 				"Function": false,

--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,17 @@
 
 		"@typescript-eslint/interface-name-prefix": 0,
 
-		"@typescript-eslint/ban-ts-ignore": 1,
+		"@typescript-eslint/ban-ts-comment": 1,
+
+		"@typescript-eslint/no-empty-function": 0,
+
+		"@typescript-eslint/ban-types": [2, {
+			"types": {
+				"Function": false,
+				"object": false,
+				"{}": false
+			}
+		}],
 
 		"import/prefer-default-export": 0,
 

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -4,6 +4,30 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@tsconfig/node10": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+			"integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+			"dev": true
+		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -201,6 +225,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.2.0",
@@ -727,12 +757,17 @@
 			}
 		},
 		"ts-node": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-			"integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+			"integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
 			"dev": true,
 			"requires": {
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.1",
 				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.17",

--- a/examples/graphql/package-lock.json
+++ b/examples/graphql/package-lock.json
@@ -4,80 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.5.4.tgz",
-			"integrity": "sha512-QJQ0NwGQMKz/G15qw4n4hOUGUX54Lm2x9bTVA0y5tsFLg0ntyDqVsCV0OjkL6RckQ5AifEzLOGDE1w1WZYMVaQ==",
-			"requires": {
-				"@davinci/reflector": "^1.0.2",
-				"@godaddy/terminus": "^4.1.0",
-				"ajv": "^7.0.0",
-				"ajv-formats": "^1.5.1",
-				"bluebird": "^3.5.0",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19",
-				"require-dir": "^1.2.0",
-				"swagger-ui-express": "^4.0.7"
-			}
-		},
-		"@davinci/graphql": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/@davinci/graphql/-/graphql-1.4.7.tgz",
-			"integrity": "sha512-cdFUh1VL8JE3VWyYyIwM7j7VU1McEx8RnWqheGpSQQCvlc+KTw5nibTg+oCwl9O2HFufs04WtzsZkuDio146gQ==",
-			"requires": {
-				"@davinci/core": "^1.5.4",
-				"@davinci/reflector": "^1.0.2",
-				"bluebird": "^3.7.2",
-				"debug": "^4.1.1",
-				"express-graphql": "0.11.0",
-				"graphql": "14.4.2",
-				"graphql-iso-date": "3.6.1",
-				"graphql-type-json": "0.3.2",
-				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-				}
-			}
-		},
-		"@davinci/mongoose": {
-			"version": "0.16.6",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.16.6.tgz",
-			"integrity": "sha512-UFgFigY0Ta5tw1wUW3vHHVX1qK6VtU+AkMtEJjrJ0UEcYRi2fAoU+sz7SzMoTsEE06rJjcKjlOsuwdM4H3WNyQ==",
-			"requires": {
-				"@davinci/core": "^1.5.4",
-				"@davinci/reflector": "^1.0.2",
-				"bluebird": "^3.7.1",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.7.2.tgz",
-			"integrity": "sha512-hiTKQUXcp84uvnr57/mFK/0xUUuzpVJsCs0hsulk5+6mA+U/drewHG58QDgoCFuWjo8ceumFP7uvr4PpmFYG9g==",
-			"requires": {
-				"stoppable": "^1.1.0"
-			}
-		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -120,6 +46,7 @@
 			"version": "4.17.22",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.22.tgz",
 			"integrity": "sha512-WdqmrUsRS4ootGha6tVwk/IVHM1iorU8tGehftQD2NWiPniw/sm7xdJOIlXLwqdInL9wBw/p7oO8vaYEF3NDmA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -175,25 +102,6 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "7.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"ajv-formats": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
-			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"requires": {
-				"ajv": "^7.0.0"
 			}
 		},
 		"arg": {
@@ -395,94 +303,6 @@
 				}
 			}
 		},
-		"express-graphql": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.11.0.tgz",
-			"integrity": "sha512-IMYmF2aIBKKfo8c+EENBNR8FAy91QHboxfaHe1omCyb49GJXsToUgcjjIF/PfWJdzn0Ofp6JJvcsODQJrqpz2g==",
-			"requires": {
-				"accepts": "^1.3.7",
-				"content-type": "^1.0.4",
-				"http-errors": "1.8.0",
-				"raw-body": "^2.4.1"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-					"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-				},
-				"http-errors": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-					"integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
-					"requires": {
-						"depd": "~1.1.2",
-						"inherits": "2.0.4",
-						"setprototypeof": "1.2.0",
-						"statuses": ">= 1.5.0 < 2",
-						"toidentifier": "1.0.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-				},
-				"raw-body": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-					"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
-					"requires": {
-						"bytes": "3.1.0",
-						"http-errors": "1.7.3",
-						"iconv-lite": "0.4.24",
-						"unpipe": "1.0.0"
-					},
-					"dependencies": {
-						"http-errors": {
-							"version": "1.7.3",
-							"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-							"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-							"requires": {
-								"depd": "~1.1.2",
-								"inherits": "2.0.4",
-								"setprototypeof": "1.1.1",
-								"statuses": ">= 1.5.0 < 2",
-								"toidentifier": "1.0.0"
-							}
-						},
-						"setprototypeof": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-							"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-						}
-					}
-				},
-				"setprototypeof": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-					"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-				},
-				"statuses": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-				}
-			}
-		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-		},
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -522,24 +342,6 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
-		"graphql": {
-			"version": "14.4.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz",
-			"integrity": "sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==",
-			"requires": {
-				"iterall": "^1.2.2"
-			}
-		},
-		"graphql-iso-date": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz",
-			"integrity": "sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q=="
-		},
-		"graphql-type-json": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-			"integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
-		},
 		"http-errors": {
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -573,16 +375,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"iterall": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
-		},
-		"json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"kareem": {
 			"version": "2.3.2",
@@ -757,11 +549,6 @@
 				"ipaddr.js": "1.9.1"
 			}
 		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -797,25 +584,10 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-		},
-		"require-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -946,11 +718,6 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -958,26 +725,6 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
-		},
-		"swagger-ui-dist": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
-			"integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg==",
-			"optional": true
-		},
-		"swagger-ui-express": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
-			"integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
-			"optional": true,
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
-		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"ts-node": {
 			"version": "8.10.2",
@@ -993,9 +740,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"type-is": {
@@ -1008,23 +755,15 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"requires": {
-				"punycode": "^2.1.0"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.16.1",
-		"ts-node": "^8.1.0",
+		"ts-node": "^10.0.0",
 		"tslib": "^2.3.0",
 		"typescript": "^4.3.5"
 	}

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/express": "4.16.1",
 		"ts-node": "^8.1.0",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/examples/rest-custom-ajv/package-lock.json
+++ b/examples/rest-custom-ajv/package-lock.json
@@ -4,6 +4,30 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@tsconfig/node10": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+			"integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+			"dev": true
+		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -201,6 +225,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.2.0",
@@ -732,12 +762,17 @@
 			"integrity": "sha512-ltrCX8+YWsqDBvCdLJwnO6VsgjV/uzLm+cTEUe0DZ1fAXIxUnNjvE/aAjXiRfNppUnCbUgZvJK1LYPAjF7W1XA=="
 		},
 		"ts-node": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-			"integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+			"integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
 			"dev": true,
 			"requires": {
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.1",
 				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.17",

--- a/examples/rest-custom-ajv/package-lock.json
+++ b/examples/rest-custom-ajv/package-lock.json
@@ -46,6 +46,7 @@
 			"version": "4.17.22",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.22.tgz",
 			"integrity": "sha512-WdqmrUsRS4ootGha6tVwk/IVHM1iorU8tGehftQD2NWiPniw/sm7xdJOIlXLwqdInL9wBw/p7oO8vaYEF3NDmA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -744,9 +745,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"type-is": {
@@ -759,9 +760,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"unpipe": {

--- a/examples/rest-custom-ajv/package.json
+++ b/examples/rest-custom-ajv/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.16.1",
-		"ts-node": "^8.1.0",
+		"ts-node": "^10.0.0",
 		"tslib": "^2.3.0",
 		"typescript": "^4.3.5"
 	}

--- a/examples/rest-custom-ajv/package.json
+++ b/examples/rest-custom-ajv/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/express": "4.16.1",
 		"ts-node": "^8.1.0",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/examples/rest/package-lock.json
+++ b/examples/rest/package-lock.json
@@ -4,6 +4,30 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@tsconfig/node10": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+			"integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+			"dev": true
+		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -201,6 +225,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.2.0",
@@ -732,12 +762,17 @@
 			"integrity": "sha512-ltrCX8+YWsqDBvCdLJwnO6VsgjV/uzLm+cTEUe0DZ1fAXIxUnNjvE/aAjXiRfNppUnCbUgZvJK1LYPAjF7W1XA=="
 		},
 		"ts-node": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-			"integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+			"integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
 			"dev": true,
 			"requires": {
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.1",
 				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.17",

--- a/examples/rest/package-lock.json
+++ b/examples/rest/package-lock.json
@@ -4,57 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.5.4.tgz",
-			"integrity": "sha512-QJQ0NwGQMKz/G15qw4n4hOUGUX54Lm2x9bTVA0y5tsFLg0ntyDqVsCV0OjkL6RckQ5AifEzLOGDE1w1WZYMVaQ==",
-			"requires": {
-				"@davinci/reflector": "^1.0.2",
-				"@godaddy/terminus": "^4.1.0",
-				"ajv": "^7.0.0",
-				"ajv-formats": "^1.5.1",
-				"bluebird": "^3.5.0",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19",
-				"require-dir": "^1.2.0",
-				"swagger-ui-express": "^4.0.7"
-			}
-		},
-		"@davinci/mongoose": {
-			"version": "0.16.6",
-			"resolved": "https://registry.npmjs.org/@davinci/mongoose/-/mongoose-0.16.6.tgz",
-			"integrity": "sha512-UFgFigY0Ta5tw1wUW3vHHVX1qK6VtU+AkMtEJjrJ0UEcYRi2fAoU+sz7SzMoTsEE06rJjcKjlOsuwdM4H3WNyQ==",
-			"requires": {
-				"@davinci/core": "^1.5.4",
-				"@davinci/reflector": "^1.0.2",
-				"bluebird": "^3.7.1",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"bluebird": {
-					"version": "3.7.2",
-					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-				}
-			}
-		},
-		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.7.2.tgz",
-			"integrity": "sha512-hiTKQUXcp84uvnr57/mFK/0xUUuzpVJsCs0hsulk5+6mA+U/drewHG58QDgoCFuWjo8ceumFP7uvr4PpmFYG9g==",
-			"requires": {
-				"stoppable": "^1.1.0"
-			}
-		},
 		"@types/body-parser": {
 			"version": "1.19.0",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -97,6 +46,7 @@
 			"version": "4.17.22",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.22.tgz",
 			"integrity": "sha512-WdqmrUsRS4ootGha6tVwk/IVHM1iorU8tGehftQD2NWiPniw/sm7xdJOIlXLwqdInL9wBw/p7oO8vaYEF3NDmA==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"@types/qs": "*",
@@ -152,25 +102,6 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "7.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"ajv-formats": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
-			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"requires": {
-				"ajv": "^7.0.0"
 			}
 		},
 		"arg": {
@@ -372,11 +303,6 @@
 				}
 			}
 		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-		},
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -449,11 +375,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"kareem": {
 			"version": "2.3.2",
@@ -628,11 +549,6 @@
 				"ipaddr.js": "1.9.1"
 			}
 		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -668,25 +584,10 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
-		},
-		"require-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -817,11 +718,6 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
 		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -834,15 +730,6 @@
 			"version": "3.35.1",
 			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.35.1.tgz",
 			"integrity": "sha512-ltrCX8+YWsqDBvCdLJwnO6VsgjV/uzLm+cTEUe0DZ1fAXIxUnNjvE/aAjXiRfNppUnCbUgZvJK1LYPAjF7W1XA=="
-		},
-		"swagger-ui-express": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
-			"integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
-			"optional": true,
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
 		},
 		"ts-node": {
 			"version": "8.10.2",
@@ -858,9 +745,9 @@
 			}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"type-is": {
@@ -873,23 +760,15 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"requires": {
-				"punycode": "^2.1.0"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/examples/rest/package.json
+++ b/examples/rest/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@types/express": "4.16.1",
-		"ts-node": "^8.1.0",
+		"ts-node": "^10.0.0",
 		"tslib": "^2.3.0",
 		"typescript": "^4.3.5"
 	}

--- a/examples/rest/package.json
+++ b/examples/rest/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@types/express": "4.16.1",
 		"ts-node": "^8.1.0",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,6 +2453,30 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
+		"@tsconfig/node10": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+			"dev": true
+		},
+		"@tsconfig/node12": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+			"dev": true
+		},
+		"@tsconfig/node14": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+			"dev": true
+		},
+		"@tsconfig/node16": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+			"integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+			"dev": true
+		},
 		"@types/bluebird": {
 			"version": "3.5.25",
 			"resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.25.tgz",
@@ -5711,6 +5735,12 @@
 				"safe-buffer": "^5.0.1",
 				"sha.js": "^2.4.8"
 			}
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -10724,9 +10754,9 @@
 			}
 		},
 		"make-error": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
 		"make-fetch-happen": {
@@ -16021,16 +16051,45 @@
 			"dev": true
 		},
 		"ts-node": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
-			"integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+			"integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
 			"dev": true,
 			"requires": {
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.1",
 				"arg": "^4.1.0",
-				"diff": "^3.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.6",
-				"yn": "^3.0.0"
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"source-map-support": {
+					"version": "0.5.19",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+					"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
 			}
 		},
 		"tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,11 +2194,39 @@
 				"glob-to-regexp": "^0.3.0"
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				}
+			}
+		},
 		"@nodelib/fs.stat": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
 			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
+			"integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			}
 		},
 		"@octokit/auth-token": {
 			"version": "2.4.5",
@@ -2459,12 +2487,6 @@
 				"@types/node": "*"
 			}
 		},
-		"@types/eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-			"dev": true
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2505,9 +2527,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
 			"dev": true
 		},
 		"@types/lodash": {
@@ -2597,53 +2619,342 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.7.0.tgz",
-			"integrity": "sha512-H5G7yi0b0FgmqaEUpzyBlVh0d9lq4cWG2ap0RKa6BkF3rpBb6IrAoubt1NWh9R2kRs/f0k6XwRDiDz3X/FqXhQ==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
+			"integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.7.0",
-				"eslint-utils": "^1.4.2",
+				"@typescript-eslint/experimental-utils": "4.28.1",
+				"@typescript-eslint/scope-manager": "4.28.1",
+				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^2.0.1",
-				"tsutils": "^3.17.1"
+				"regexpp": "^3.1.0",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"regexpp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.7.0.tgz",
-			"integrity": "sha512-9/L/OJh2a5G2ltgBWJpHRfGnt61AgDeH6rsdg59BH0naQseSwR7abwHq3D5/op0KYD/zFT4LS5gGvWcMmegTEg==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
+			"integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.7.0",
-				"eslint-scope": "^5.0.0"
+				"@types/json-schema": "^7.0.7",
+				"@typescript-eslint/scope-manager": "4.28.1",
+				"@typescript-eslint/types": "4.28.1",
+				"@typescript-eslint/typescript-estree": "4.28.1",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.7.0.tgz",
-			"integrity": "sha512-ctC0g0ZvYclxMh/xI+tyqP0EC2fAo6KicN9Wm2EIao+8OppLfxji7KAGJosQHSGBj3TcqUrA96AjgXuKa5ob2g==",
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
+			"integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.7.0",
-				"@typescript-eslint/typescript-estree": "2.7.0",
-				"eslint-visitor-keys": "^1.1.0"
+				"@typescript-eslint/scope-manager": "4.28.1",
+				"@typescript-eslint/types": "4.28.1",
+				"@typescript-eslint/typescript-estree": "4.28.1",
+				"debug": "^4.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
 			}
 		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.7.0.tgz",
-			"integrity": "sha512-vVCE/DY72N4RiJ/2f10PTyYekX2OLaltuSIBqeHYI44GQ940VCYioInIb8jKMrK9u855OEJdFC+HmWAZTnC+Ag==",
+		"@typescript-eslint/scope-manager": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
+			"integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.1.1",
-				"glob": "^7.1.4",
+				"@typescript-eslint/types": "4.28.1",
+				"@typescript-eslint/visitor-keys": "4.28.1"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+			"integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+			"integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.28.1",
+				"@typescript-eslint/visitor-keys": "4.28.1",
+				"debug": "^4.3.1",
+				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
-				"lodash.unescape": "4.0.1",
-				"semver": "^6.3.0",
-				"tsutils": "^3.17.1"
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+					"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"dev": true,
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+					"integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.2",
+						"@nodelib/fs.walk": "^1.2.3",
+						"glob-parent": "^5.1.2",
+						"merge2": "^1.3.0",
+						"micromatch": "^4.0.4"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "11.0.4",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"dev": true,
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.8",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.2.3"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+			"integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.28.1",
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
 			}
 		},
 		"@vue/babel-helper-vue-jsx-merge-props": {
@@ -4354,6 +4665,14 @@
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				}
 			}
 		},
 		"ci-info": {
@@ -6945,6 +7264,15 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+			"integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"faye-websocket": {
 			"version": "0.10.0",
@@ -10320,12 +10648,6 @@
 				"lodash._reinterpolate": "^3.0.0"
 			}
 		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-			"dev": true
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12389,6 +12711,12 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
+		"picomatch": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+			"dev": true
+		},
 		"pify": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -13349,6 +13677,12 @@
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
 		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
+		},
 		"quick-lru": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -13891,6 +14225,12 @@
 			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -13931,6 +14271,15 @@
 				"is-promise": "^2.1.0"
 			}
 		},
+		"run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
 		"run-queue": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -13947,6 +14296,14 @@
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				}
 			}
 		},
 		"safe-buffer": {
@@ -15677,18 +16034,26 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"tsutils": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				}
 			}
 		},
 		"tty-browserify": {
@@ -15750,9 +16115,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"uc.micro": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"nyc": "14.0.0",
 		"should": "^13.2.3",
 		"sinon": "4.5.0",
-		"ts-node": "8.0.3",
+		"ts-node": "^10.0.0",
 		"tslib": "^2.3.0",
 		"typescript": "^4.3.5",
 		"vuepress": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
 		"@types/mocha": "5.2.5",
 		"@types/node": "11.13.8",
 		"@types/sinon": "7.0.11",
-		"@typescript-eslint/eslint-plugin": "2.7.0",
-		"@typescript-eslint/parser": "2.7.0",
+		"@typescript-eslint/eslint-plugin": "^4.28.1",
+		"@typescript-eslint/parser": "^4.28.1",
 		"@vuepress/plugin-pwa": "1.2.0",
 		"ajv": "^7.0.0",
 		"ajv-errors": "^2.0.0",
@@ -38,8 +38,8 @@
 		"should": "^13.2.3",
 		"sinon": "4.5.0",
 		"ts-node": "8.0.3",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5",
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5",
 		"vuepress": "1.2.0"
 	}
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -565,9 +565,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"type-is": {
@@ -581,9 +581,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"unpipe": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
 		"ajv": "^7.0.0",
 		"ajv-errors": "^2.0.0",
 		"ajv-formats": "^1.5.1",
-		"bluebird": "^3.5.0",
+		"bluebird": "^3.7.2",
 		"debug": "^4.1.1",
 		"lodash": "^4.17.19",
 		"require-dir": "^1.2.0"
@@ -39,7 +39,7 @@
 	"devDependencies": {
 		"@types/mocha": "^5.2.7",
 		"express": "^4.16.4",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
 		"build": "npm run build-cj && npm run build-esm",
 		"build-cj": "tsc -p tsconfig.cjs.release.json",
 		"build-esm": "tsc -p tsconfig.esm.release.json",
-		"eslint": "../../node_modules/eslint/bin/eslint.js --c .eslintrc 'src/**/*.ts'",
+		"eslint": "../../node_modules/eslint/bin/eslint.js --color --c .eslintrc 'src/**/*.ts'",
 		"pretest": "npm run eslint && npm run build",
 		"test": "mocha --exit",
 		"cover": "nyc npm test"

--- a/packages/core/src/createApp.ts
+++ b/packages/core/src/createApp.ts
@@ -66,7 +66,7 @@ export const processArgs = (...args) => {
 		runMiddlewares = options;
 	}
 	if (!options) options = {};
-	if (!runMiddlewares) runMiddlewares = () => {};
+	if (!runMiddlewares) runMiddlewares = () => undefined;
 	// if (args.length === 3) then no change
 
 	// for 3 arguments then we can assume app, options and callback are set

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -343,21 +343,6 @@ const validateController = (Controller: ClassType) => {
 	if (typeof Controller !== 'function') throw new Error('Invalid Controller - not function');
 };
 
-function processParameters(params: [CreateRouterParameters] | CreateRouterParametersArray): CreateRouterParameters {
-	// need to validate the inputs here
-	if (!params?.[0]) throw new Error('Invalid Controller - missing Controller');
-
-	// object parameter, returning it
-	if ('Controller' in params?.[0]) return params?.[0];
-
-	return {
-		Controller: params[0],
-		resourceName: params[1],
-		contextFactory: params[2],
-		router: params[3]
-	};
-}
-
 export type CreateRouterParameters = {
 	Controller: ClassType;
 	resourceName?: string | null;
@@ -372,6 +357,21 @@ type CreateRouterParametersArray = [
 	ContextFactory | null | undefined,
 	Router | undefined
 ];
+
+function processParameters(params: [CreateRouterParameters] | CreateRouterParametersArray): CreateRouterParameters {
+	// need to validate the inputs here
+	if (!params?.[0]) throw new Error('Invalid Controller - missing Controller');
+
+	// object parameter, returning it
+	if ('Controller' in params?.[0]) return params?.[0];
+
+	return {
+		Controller: params[0],
+		resourceName: params[1],
+		contextFactory: params[2],
+		router: params[3]
+	};
+}
 
 function createRouterAndSwaggerDoc(parameters: CreateRouterParameters): Router | DaVinciExpress;
 /**

--- a/packages/core/src/route/types.ts
+++ b/packages/core/src/route/types.ts
@@ -70,6 +70,11 @@ export interface PathsDefinition {
 	};
 }
 
+export interface MethodValidation {
+	disable?: boolean;
+	partial?: boolean;
+}
+
 export interface PathsValidationOptions {
 	[key: string]: {
 		[key in Verb]: MethodValidation;
@@ -111,11 +116,6 @@ export interface IMethodResponseOutput {
 
 export interface IMethodResponses {
 	[key: number]: Function | IMethodResponseOutput | ((string) => IMethodResponseOutput);
-}
-
-export interface MethodValidation {
-	disable?: boolean;
-	partial?: boolean;
 }
 
 export interface IMethodDecoratorOptions {

--- a/packages/core/test/mocha.opts
+++ b/packages/core/test/mocha.opts
@@ -1,3 +1,4 @@
+--color
 --reporter spec
 --ui bdd
 --recursive

--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -4,36 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.5.4.tgz",
-			"integrity": "sha512-QJQ0NwGQMKz/G15qw4n4hOUGUX54Lm2x9bTVA0y5tsFLg0ntyDqVsCV0OjkL6RckQ5AifEzLOGDE1w1WZYMVaQ==",
-			"requires": {
-				"@davinci/reflector": "^1.0.2",
-				"@godaddy/terminus": "^4.1.0",
-				"ajv": "^7.0.0",
-				"ajv-formats": "^1.5.1",
-				"bluebird": "^3.5.0",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19",
-				"require-dir": "^1.2.0",
-				"swagger-ui-express": "^4.0.7"
-			}
-		},
 		"@davinci/reflector": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
 			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
 			"requires": {
 				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.7.2.tgz",
-			"integrity": "sha512-hiTKQUXcp84uvnr57/mFK/0xUUuzpVJsCs0hsulk5+6mA+U/drewHG58QDgoCFuWjo8ceumFP7uvr4PpmFYG9g==",
-			"requires": {
-				"stoppable": "^1.1.0"
 			}
 		},
 		"@types/graphql": {
@@ -58,25 +34,6 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			}
-		},
-		"ajv": {
-			"version": "7.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"ajv-formats": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
-			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"requires": {
-				"ajv": "^7.0.0"
 			}
 		},
 		"bluebird": {
@@ -117,11 +74,6 @@
 				"http-errors": "1.8.0",
 				"raw-body": "^2.4.1"
 			}
-		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"graphql": {
 			"version": "14.4.2",
@@ -171,11 +123,6 @@
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
 			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
-		"json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-		},
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -203,11 +150,6 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"raw-body": {
 			"version": "2.4.1",
@@ -244,16 +186,6 @@
 			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
 			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
 		},
-		"require-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -269,55 +201,27 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-		},
-		"swagger-ui-dist": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
-			"integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg==",
-			"optional": true
-		},
-		"swagger-ui-express": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
-			"integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
-			"optional": true,
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
-		},
 		"toidentifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
 			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"requires": {
-				"punycode": "^2.1.0"
-			}
 		}
 	}
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -10,7 +10,7 @@
 		"build": "npm run build-cj && npm run build-esm",
 		"build-cj": "tsc -p tsconfig.cjs.release.json",
 		"build-esm": "tsc -p tsconfig.esm.release.json",
-		"eslint": "../../node_modules/eslint/bin/eslint.js --c .eslintrc 'src/**/*.ts'",
+		"eslint": "../../node_modules/eslint/bin/eslint.js --color --c .eslintrc 'src/**/*.ts'",
 		"pretest": "npm run eslint && npm run build",
 		"test": "mocha --exit",
 		"cover": "nyc npm test"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -31,7 +31,7 @@
 	"devDependencies": {
 		"@types/graphql": "14.5.0",
 		"@types/mocha": "^5.2.6",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/packages/graphql/src/createControllerSchemas.ts
+++ b/packages/graphql/src/createControllerSchemas.ts
@@ -51,9 +51,9 @@ export const createControllerSchemas = (
 	Controller: ClassType,
 	{ queries: q, mutations: m, schemas: s } = { queries: {}, mutations: {}, schemas: {} }
 ) => {
-	// eslint-disable-next-line @typescript-eslint/no-use-before-define
+	// eslint-disable-next-line no-use-before-define
 	const { queries, schemas: queriesSchemas } = createResolversAndSchemas(Controller, 'queries', s);
-	// eslint-disable-next-line @typescript-eslint/no-use-before-define
+	// eslint-disable-next-line no-use-before-define
 	const { mutations, schemas: allSchemas } = createResolversAndSchemas(Controller, 'mutations', queriesSchemas);
 
 	return { queries: { ...q, ...queries }, mutations: { ...m, ...mutations }, schemas: allSchemas };

--- a/packages/graphql/src/createGraphQLServer.ts
+++ b/packages/graphql/src/createGraphQLServer.ts
@@ -115,13 +115,7 @@ export const createGraphQLServer = (
 
 	const writeSDLtoFile = async path => {
 		const sdl = printSDL();
-		return new Promise((resolve, reject) =>
-			fs.writeFile(path, sdl, err => {
-				if (err) return reject(err);
-
-				return resolve();
-			})
-		);
+		await fs.promises.writeFile(path, sdl);
 	};
 
 	return { app, schema, printSDL, writeSDLtoFile };

--- a/packages/graphql/src/generateSchema.ts
+++ b/packages/graphql/src/generateSchema.ts
@@ -148,7 +148,7 @@ export const generateGQLSchema = ({
 				...metadata.opts,
 				name,
 
-				// eslint-disable-next-line @typescript-eslint/no-use-before-define
+				// eslint-disable-next-line no-use-before-define
 				fields: createObjectFields({
 					parentType: type,
 					schemas,

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -35,6 +35,13 @@ export interface IFieldDecoratorOptions {
 	asInput?: boolean;
 }
 
+export interface IResolverDecoratorMetadata {
+	name: string;
+	methodName: string;
+	returnType: any;
+	handler: Function;
+}
+
 export interface IFieldDecoratorOptionsFactoryArgs {
 	isInput: boolean;
 	operationType: OperationType;
@@ -47,13 +54,6 @@ export interface IFieldDecoratorMetadata {
 	key: any;
 	opts?: IFieldDecoratorOptions;
 	optsFactory?: FieldDecoratorOptionsFactory;
-}
-
-export interface IResolverDecoratorMetadata {
-	name: string;
-	methodName: string;
-	returnType: any;
-	handler: Function;
 }
 
 export type SelectionSet<T> = { [P in keyof T]?: boolean | SelectionSet<T[P]> };

--- a/packages/graphql/test/mocha.opts
+++ b/packages/graphql/test/mocha.opts
@@ -1,3 +1,4 @@
+--color
 --reporter spec
 --ui bdd
 --recursive

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -435,15 +435,15 @@
 			}
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		},
 		"uri-js": {

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@davinci/reflector": "^1.0.3",
-		"bluebird": "^3.7.1",
+		"bluebird": "^3.7.2",
 		"debug": "^4.1.1",
 		"lodash": "^4.17.19"
 	},
@@ -34,7 +34,7 @@
 		"@davinci/core": "^1.0.0",
 		"mongoose": "^5.11.0",
 		"prettier": "1.19.1",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -12,7 +12,7 @@
 		"build": "npm run build-cj && npm run build-esm",
 		"build-cj": "tsc -p tsconfig.cjs.release.json",
 		"build-esm": "tsc -p tsconfig.esm.release.json",
-		"eslint": "../../node_modules/eslint/bin/eslint.js --c .eslintrc 'src/**/*.ts'",
+		"eslint": "../../node_modules/eslint/bin/eslint.js --color --c .eslintrc 'src/**/*.ts'",
 		"pretest": "npm run eslint && npm run build",
 		"test": "mocha --exit",
 		"cover": "nyc npm test"

--- a/packages/mongoose/test/mocha.opts
+++ b/packages/mongoose/test/mocha.opts
@@ -1,3 +1,4 @@
+--color
 --reporter spec
 --ui bdd
 --recursive

--- a/packages/reflector/package-lock.json
+++ b/packages/reflector/package-lock.json
@@ -16,15 +16,15 @@
 			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
 		}
 	}

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -6,7 +6,7 @@
 	"types": "build/index.d.ts",
 	"scripts": {
 		"build": "tsc -p ./tsconfig.release.json",
-		"eslint": "../../node_modules/eslint/bin/eslint.js --c .eslintrc 'src/**/*.ts'",
+		"eslint": "../../node_modules/eslint/bin/eslint.js --color --c .eslintrc 'src/**/*.ts'",
 		"pretest": "npm run eslint && npm run build",
 		"test": "mocha --exit",
 		"cover": "nyc npm test"

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@types/mocha": "^5.2.6",
-		"tslib": "^1.9.3",
-		"typescript": "^3.7.5"
+		"tslib": "^2.3.0",
+		"typescript": "^4.3.5"
 	}
 }

--- a/packages/reflector/src/shared-types.ts
+++ b/packages/reflector/src/shared-types.ts
@@ -19,14 +19,5 @@ export type ReturnTypeFunc = (returns?: void) => ReturnTypeFuncValue;
 export type TypeValueFactory = (type?: void) => TypeValue;
 export type ClassTypeResolver = (of?: void) => ClassType;
 
-/**
- * Create types from values in array:
- *
- * const values = ['A', 'B'] as const
- * type Foo = ElementType<typeof values> // this is correctly inferred as literal "A" | "B"
- */
-export type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<infer ElementType>
-	? ElementType
-	: never;
 
 export type Thunk<T> = (() => T) | T;

--- a/packages/reflector/test/mocha.opts
+++ b/packages/reflector/test/mocha.opts
@@ -1,3 +1,4 @@
+--color
 --reporter spec
 --ui bdd
 --recursive


### PR DESCRIPTION
This PR updates the following TypeScript dependencies to the latest versions
- `typescript` from `3.7.5` to `4.3.5`
- `tslib` from `1.9.3` to `2.3.0`
- `ts-node` from `8.3.0` to `10.0.0`
- `@typescript-eslint/eslint-plugin` from `2.7.0` to `4.28.1`
- `@typescript-eslint/parser` from `2.7.0` to `4.28.1`
- `bluebird` from multiple versions to `3.7.2`

It makes as few code changes as possible, the majority consisting of moving a few types within the file to eliminate "used before defined" errors. 

### Note about `ban-types`

This PR explicitly disables some `ban-types` rules which were introduced at some point in a more recent release.

Da Vinci currently uses all three (`Function`, `object` and `{}`) so to avoid refactoring a lot of code in this PR, I disabled the rule and will create a subsequent PR that makes the necessary changes to re-enable that `ban-types` rule. 

### Colors

This also forces colour output for both `eslint` and `mocha`, which wasn't showing when being run as a child process from `lerna`. Now we get colour when running both locally with `lerna run test` as well as on CircleCI:

![image](https://user-images.githubusercontent.com/710204/124450831-b6f31800-dd7c-11eb-8239-31b4383ba42e.png)
