### PR TITLE
fix: graphql resolver union + failure on node14

### DIFF
--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -4,14 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
 		"@types/graphql": {
 			"version": "14.5.0",
 			"resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
@@ -36,6 +28,12 @@
 				"negotiator": "0.6.2"
 			}
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -46,10 +44,41 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
+		"call-bind": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.2"
+			}
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
+		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"cookiejar": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.3.1",
@@ -58,6 +87,12 @@
 			"requires": {
 				"ms": "2.1.2"
 			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -73,6 +108,46 @@
 				"content-type": "^1.0.4",
 				"http-errors": "1.8.0",
 				"raw-body": "^2.4.1"
+			}
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+			"dev": true
+		},
+		"form-data": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"formidable": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+			"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"graphql": {
@@ -92,6 +167,21 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
 			"integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-symbols": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"dev": true
 		},
 		"http-errors": {
 			"version": "1.8.0",
@@ -128,6 +218,27 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"dev": true
+		},
+		"mime": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+			"dev": true
+		},
 		"mime-db": {
 			"version": "1.45.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -150,6 +261,21 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+		},
+		"object-inspect": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+			"integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+			"dev": true,
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
 		},
 		"raw-body": {
 			"version": "2.4.1",
@@ -181,25 +307,95 @@
 				}
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
+		"semver": {
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
+		},
 		"setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 		},
+		"side-channel": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.0",
+				"get-intrinsic": "^1.0.2",
+				"object-inspect": "^1.9.0"
+			}
+		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"superagent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+			"integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "^1.3.0",
+				"cookiejar": "^2.1.2",
+				"debug": "^4.1.1",
+				"fast-safe-stringify": "^2.0.7",
+				"form-data": "^3.0.0",
+				"formidable": "^1.2.2",
+				"methods": "^1.1.2",
+				"mime": "^2.4.6",
+				"qs": "^6.9.4",
+				"readable-stream": "^3.6.0",
+				"semver": "^7.3.2"
+			}
+		},
+		"supertest": {
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.3.tgz",
+			"integrity": "sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==",
+			"dev": true,
+			"requires": {
+				"methods": "^1.1.2",
+				"superagent": "^6.1.0"
+			}
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -222,6 +418,18 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		}
 	}
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -31,6 +31,7 @@
 	"devDependencies": {
 		"@types/graphql": "14.5.0",
 		"@types/mocha": "^5.2.6",
+		"supertest": "^6.1.3",
 		"tslib": "^2.3.0",
 		"typescript": "^4.3.5"
 	}

--- a/packages/graphql/src/createGraphQLServer.ts
+++ b/packages/graphql/src/createGraphQLServer.ts
@@ -51,9 +51,9 @@ export const createGraphQLServer = (
 	);
 
 	const allSchemas = { queries: {}, mutations: {}, schemas: {} };
-	const { queries: queryFields, mutations: mutationsFields, schemas: controllerSchemas } = (controllers || []).reduce(
+	const { queries: queryFields, mutations: mutationsFields } = (controllers || []).reduce(
 		(acc, controller) => {
-			_.merge(allSchemas, controllerSchemas);
+			_.merge(allSchemas, acc.schemas);
 			const { queries, mutations, schemas } = createControllerSchemas(controller, allSchemas);
 			if (queries) {
 				acc.queries = _.merge({}, acc.queries || {}, queries);

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -121,7 +121,7 @@ export function arg(options?: IArgOptions): Function {
 export function fieldResolver<T = {}>(
 	resolverOf: ClassType,
 	fieldName: keyof T,
-	returnType: ClassType | ClassType[]
+	returnType: ReturnTypeFuncValue
 ): Function {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props

--- a/packages/graphql/test/unit/createGraphQLServer.test.ts
+++ b/packages/graphql/test/unit/createGraphQLServer.test.ts
@@ -1,0 +1,61 @@
+/*
+ * © Copyright 2020 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+import express from 'express';
+import { DaVinciExpress } from '@davinci/core';
+import should from 'should';
+import supertest from 'supertest';
+
+import { graphql, createGraphQLServer } from '../../src';
+
+describe('server instantiation', () => {
+	let app: DaVinciExpress;
+
+	beforeEach(() => {
+		app = express() as DaVinciExpress;
+	});
+
+	describe('#createGraphQLServer', () => {
+		it('should mount the graphql middleware in POST /graphql', async () => {
+			class Customer {
+				@graphql.field()
+				firstname: string;
+				@graphql.field()
+				age: number;
+			}
+
+			class CustomerController {
+				@graphql.query([Customer])
+				customers() {
+					return [{ firstname: 'John', age: 20 }];
+				}
+			}
+
+			createGraphQLServer(app, [CustomerController]);
+
+			// verify that the middleware is in the express stack
+			const route = app._router.stack.find(({ name }) => name === 'graphqlMiddleware');
+			should(route).be.ok();
+
+			// test the endpoint
+			const response = await supertest(app)
+				.post('/graphql')
+				.send({ query: 'query{customers { firstname age }}' })
+				.expect(200);
+
+			response.body.should.be.deepEqual({
+				data: {
+					customers: [
+						{
+							firstname: 'John',
+							age: 20
+						}
+					]
+				}
+			});
+			response.statusCode.should.be.equal(200);
+		});
+	});
+});

--- a/packages/graphql/test/unit/createGraphQLServer.test.ts
+++ b/packages/graphql/test/unit/createGraphQLServer.test.ts
@@ -38,12 +38,29 @@ describe('server instantiation', () => {
 			// verify that the middleware is in the express stack
 			const route = app._router.stack.find(({ name }) => name === 'graphqlMiddleware');
 			should(route).be.ok();
+		});
+
+		it('should accept handle GraphQL queries', async () => {
+			class Customer {
+				@graphql.field()
+				firstname: string;
+				@graphql.field()
+				age: number;
+			}
+
+			class CustomerController {
+				@graphql.query([Customer])
+				customers() {
+					return [{ firstname: 'John', age: 20 }];
+				}
+			}
+
+			createGraphQLServer(app, [CustomerController]);
 
 			// test the endpoint
 			const response = await supertest(app)
 				.post('/graphql')
-				.send({ query: 'query{customers { firstname age }}' })
-				.expect(200);
+				.send({ query: 'query{customers { firstname age }}' });
 
 			response.body.should.be.deepEqual({
 				data: {
@@ -53,6 +70,45 @@ describe('server instantiation', () => {
 							age: 20
 						}
 					]
+				}
+			});
+			response.statusCode.should.be.equal(200);
+		});
+
+		it('should accept handle GraphQL mutations', async () => {
+			class Customer {
+				@graphql.field()
+				firstname: string;
+				@graphql.field()
+				age: number;
+			}
+
+			class CustomerController {
+				@graphql.mutation(Customer)
+				uppercaseName(@graphql.arg() customer: Customer) {
+					return { ...customer, firstname: customer.firstname.toUpperCase() };
+				}
+
+				@graphql.query(String)
+				myQuery() {}
+			}
+
+			createGraphQLServer(app, [CustomerController]);
+
+			// test the endpoint
+			const response = await supertest(app)
+				.post('/graphql')
+				.send({
+					query: 'mutation { uppercaseName( customer: { firstname: "John", age: 20 } ) { firstname age }}',
+					variables: {}
+				});
+
+			response.body.should.be.deepEqual({
+				data: {
+					uppercaseName: {
+						age: 20,
+						firstname: 'JOHN'
+					}
 				}
 			});
 			response.statusCode.should.be.equal(200);

--- a/packages/graphql/test/unit/createGraphQLServer.test.ts
+++ b/packages/graphql/test/unit/createGraphQLServer.test.ts
@@ -10,108 +10,106 @@ import supertest from 'supertest';
 
 import { graphql, createGraphQLServer } from '../../src';
 
-describe('server instantiation', () => {
+describe('createGraphQLServer', () => {
 	let app: DaVinciExpress;
 
 	beforeEach(() => {
 		app = express() as DaVinciExpress;
 	});
 
-	describe('#createGraphQLServer', () => {
-		it('should mount the graphql middleware in POST /graphql', async () => {
-			class Customer {
-				@graphql.field()
-				firstname: string;
-				@graphql.field()
-				age: number;
+	it('should mount the graphql middleware in POST /graphql', async () => {
+		class Customer {
+			@graphql.field()
+			firstname: string;
+			@graphql.field()
+			age: number;
+		}
+
+		class CustomerController {
+			@graphql.query([Customer])
+			customers() {
+				return [{ firstname: 'John', age: 20 }];
 			}
+		}
 
-			class CustomerController {
-				@graphql.query([Customer])
-				customers() {
-					return [{ firstname: 'John', age: 20 }];
-				}
+		createGraphQLServer(app, [CustomerController]);
+
+		// verify that the middleware is in the express stack
+		const route = app._router.stack.find(({ name }) => name === 'graphqlMiddleware');
+		should(route).be.ok();
+	});
+
+	it('should accept handle GraphQL queries', async () => {
+		class Customer {
+			@graphql.field()
+			firstname: string;
+			@graphql.field()
+			age: number;
+		}
+
+		class CustomerController {
+			@graphql.query([Customer])
+			customers() {
+				return [{ firstname: 'John', age: 20 }];
 			}
+		}
 
-			createGraphQLServer(app, [CustomerController]);
+		createGraphQLServer(app, [CustomerController]);
 
-			// verify that the middleware is in the express stack
-			const route = app._router.stack.find(({ name }) => name === 'graphqlMiddleware');
-			should(route).be.ok();
-		});
+		// test the endpoint
+		const response = await supertest(app)
+			.post('/graphql')
+			.send({ query: 'query{customers { firstname age }}' });
 
-		it('should accept handle GraphQL queries', async () => {
-			class Customer {
-				@graphql.field()
-				firstname: string;
-				@graphql.field()
-				age: number;
-			}
-
-			class CustomerController {
-				@graphql.query([Customer])
-				customers() {
-					return [{ firstname: 'John', age: 20 }];
-				}
-			}
-
-			createGraphQLServer(app, [CustomerController]);
-
-			// test the endpoint
-			const response = await supertest(app)
-				.post('/graphql')
-				.send({ query: 'query{customers { firstname age }}' });
-
-			response.body.should.be.deepEqual({
-				data: {
-					customers: [
-						{
-							firstname: 'John',
-							age: 20
-						}
-					]
-				}
-			});
-			response.statusCode.should.be.equal(200);
-		});
-
-		it('should accept handle GraphQL mutations', async () => {
-			class Customer {
-				@graphql.field()
-				firstname: string;
-				@graphql.field()
-				age: number;
-			}
-
-			class CustomerController {
-				@graphql.mutation(Customer)
-				uppercaseName(@graphql.arg() customer: Customer) {
-					return { ...customer, firstname: customer.firstname.toUpperCase() };
-				}
-
-				@graphql.query(String)
-				myQuery() {}
-			}
-
-			createGraphQLServer(app, [CustomerController]);
-
-			// test the endpoint
-			const response = await supertest(app)
-				.post('/graphql')
-				.send({
-					query: 'mutation { uppercaseName( customer: { firstname: "John", age: 20 } ) { firstname age }}',
-					variables: {}
-				});
-
-			response.body.should.be.deepEqual({
-				data: {
-					uppercaseName: {
-						age: 20,
-						firstname: 'JOHN'
+		response.body.should.be.deepEqual({
+			data: {
+				customers: [
+					{
+						firstname: 'John',
+						age: 20
 					}
-				}
-			});
-			response.statusCode.should.be.equal(200);
+				]
+			}
 		});
+		response.statusCode.should.be.equal(200);
+	});
+
+	it('should accept handle GraphQL mutations', async () => {
+		class Customer {
+			@graphql.field()
+			firstname: string;
+			@graphql.field()
+			age: number;
+		}
+
+		class CustomerController {
+			@graphql.mutation(Customer)
+			uppercaseName(@graphql.arg() customer: Customer) {
+				return { ...customer, firstname: customer.firstname.toUpperCase() };
+			}
+
+			@graphql.query(String)
+			myQuery() {}
+		}
+
+		createGraphQLServer(app, [CustomerController]);
+
+		// test the endpoint
+		const response = await supertest(app)
+			.post('/graphql')
+			.send({
+				query: 'mutation { uppercaseName( customer: { firstname: "John", age: 20 } ) { firstname age }}',
+				variables: {}
+			});
+
+		response.body.should.be.deepEqual({
+			data: {
+				uppercaseName: {
+					age: 20,
+					firstname: 'JOHN'
+				}
+			}
+		});
+		response.statusCode.should.be.equal(200);
 	});
 });


### PR DESCRIPTION
### Changes
- the fieldResolver returnType parameter is now of type `ReturnTypeFuncValue`. It allows to return Union types. ([link](https://github.com/HPInc/davinci/compare/fix/graphql-resolver-union?expand=1#diff-c66b7b9b380c52d7e590a51ffea6d20d674fce3459e835f92340654c30f0b18bR124))
- fixed a variable access issue that was preventing DaVinci to start on nodejs14+ ([link](https://github.com/HPInc/davinci/compare/fix/graphql-resolver-union?expand=1#diff-f311c62bb2cd250d058384421cf4a8bfc86240c83e1fb1e2c0cf5d70d4ca56e4R54))
- added createGraphQLServer unit test