### PR TITLE
chore: codecov flags for lerna packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,11 @@ jobs:
           steps:
             - run:
                 name: upload coverage report
-                command: npx codecov
+                command: |
+                  npx codecov -f packages/core/coverage/lcov.info -F core
+                  npx codecov -f packages/graphql/coverage/lcov.info -F graphql
+                  npx codecov -f packages/mongoose/coverage/lcov.info -F mongoose
+                  npx codecov -f packages/reflector/coverage/lcov.info -F reflector
             - save_cache:
                 key: v1-source-{{ .Environment.CIRCLE_SHA1 }}
                 paths:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+      core:
+        flags:
+          - core
+      reflector:
+        flags:
+          - reflector
+      mongoose:
+        flags:
+          - mongoose
+      graphql:
+        flags:
+          - graphql
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+
+flags:
+  core:
+    paths:
+      - packages/core
+  graphql:
+    paths:
+      - packages/graphql
+  mongoose:
+    paths:
+      - packages/mongoose
+  reflector:
+    paths:
+      - packages/reflector

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,12 +27,16 @@ flags:
   core:
     paths:
       - packages/core
+    carryforward: true
   graphql:
     paths:
       - packages/graphql
+    carryforward: true
   mongoose:
     paths:
       - packages/mongoose
+    carryforward: true
   reflector:
     paths:
       - packages/reflector
+    carryforward: true


### PR DESCRIPTION
This PR configures [Codecov flags](https://docs.codecov.com/docs/flags) on the repository. 

This gives us better visibility on the coverage for each package in the Lerna workspace, as shown below in the Codecov comment: 
![image](https://user-images.githubusercontent.com/710204/124758421-7b944d00-df26-11eb-958b-6cb0d33069c3.png)

