### PR TITLE
Improved decorator types

### DIFF
--- a/packages/core/src/express/decorators/context.ts
+++ b/packages/core/src/express/decorators/context.ts
@@ -9,7 +9,7 @@ import find from 'lodash/find';
 /**
  * Decorate a parameter as context
  */
-export const context = (): Function => {
+export const context = (): ParameterDecorator => {
 	return function(target: Record<string, any>, methodName: string, index) {
 		const contextParameters = Reflector.getMetadata('davinci:context', target.constructor) || [];
 		const isAlreadySet = !!find(contextParameters, { methodName, index });

--- a/packages/core/src/express/decorators/express.ts
+++ b/packages/core/src/express/decorators/express.ts
@@ -11,11 +11,11 @@ import { IHeaderDecoratorMetadata } from '../types';
  * Factory function that generates a `req` or `res` decorator
  * @param reqOrRes
  */
-export const createReqResExpressDecorator = (reqOrRes: 'req' | 'res') => () => (
+export const createReqResExpressDecorator = (reqOrRes: 'req' | 'res') => (): ParameterDecorator => (
 	prototype: Record<string, any>,
 	methodName: string,
 	index
-) => {
+): void => {
 	// get the existing metadata props
 	const methodParameters =
 		Reflector.getMetadata('davinci:openapi:method-parameters', prototype.constructor) || [];
@@ -93,7 +93,7 @@ export { middleware };
  * @param name
  * @param value
  */
-export const header = (name: string, value: string) => {
+export const header = (name: string, value: string): MethodDecorator => {
 	return function(prototype: Record<string, any>, methodName: string) {
 		const meta: IHeaderDecoratorMetadata = { name, value, handler: prototype[methodName] };
 		// define new metadata methods

--- a/packages/core/src/express/decorators/express.ts
+++ b/packages/core/src/express/decorators/express.ts
@@ -48,8 +48,8 @@ type Stage = 'before' | 'after';
  * @param middlewareFunction
  * @param stage
  */
-const middleware = (middlewareFunction, stage: Stage = 'before'): Function => {
-	return function(target: Record<string, any> | Function, methodName: string) {
+const middleware = (middlewareFunction, stage: Stage = 'before'): ClassDecorator & MethodDecorator => {
+	return function(target: Record<string, any> | Function, methodName?: string) {
 		const args: {
 			middlewareFunction: Function;
 			stage: Stage;
@@ -69,8 +69,6 @@ const middleware = (middlewareFunction, stage: Stage = 'before'): Function => {
 
 		// define new metadata methods
 		Reflector.unshiftMetadata('davinci:express:method-middleware', args, realTarget);
-
-		return target;
 	};
 };
 

--- a/packages/core/src/route/decorators/openapi.ts
+++ b/packages/core/src/route/decorators/openapi.ts
@@ -16,7 +16,7 @@ import {
  * It annotates a variable as swagger definition property
  * @param {IPropDecoratorOptions} opts
  */
-export function prop<T = any>(opts?: IPropDecoratorOptions<T> | IPropDecoratorOptionsFactory<T>) {
+export function prop<T = any>(opts?: IPropDecoratorOptions<T> | IPropDecoratorOptionsFactory<T>): PropertyDecorator {
 	return function(prototype: Record<string, any>, key: string): void {
 		const optsFactory = () => {
 			const options = typeof opts === 'function' ? opts() : opts;
@@ -36,7 +36,7 @@ export function prop<T = any>(opts?: IPropDecoratorOptions<T> | IPropDecoratorOp
  * Its definition will be added in the `definitions` property
  * @param options
  */
-export function definition<T = any>(options?: IDefinitionDecoratorOptions<T>) {
+export function definition<T = any>(options?: IDefinitionDecoratorOptions<T>): ClassDecorator {
 	return function(target: Function): void {
 		Reflector.defineMetadata('davinci:openapi:definition', options ?? {}, target);
 	};

--- a/packages/core/src/route/decorators/route.ts
+++ b/packages/core/src/route/decorators/route.ts
@@ -12,7 +12,7 @@ import { IMethodParameter, IMethodParameterBase, IMethodDecoratorOptions, IMetho
  * @param verb
  */
 export const createRouteMethodDecorator = verb =>
-	function({ path, summary, description, responses, validation, hidden }: IMethodDecoratorOptions): Function {
+	function({ path, summary, description, responses, validation, hidden }: IMethodDecoratorOptions): MethodDecorator {
 		return function(prototype: object, methodName: string) {
 			// get the existing metadata props
 			const methods = Reflector.getMetadata('davinci:openapi:methods', prototype.constructor) || [];
@@ -49,7 +49,7 @@ export const head = createRouteMethodDecorator('head');
  * Decorator that annotate a method parameter
  * @param options
  */
-export function param(options: IMethodParameter): Function {
+export function param(options: IMethodParameter): ParameterDecorator {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props
 		const methodParameters =
@@ -87,7 +87,7 @@ type CreateParamDecoratorFunctionArg = IMethodParameterBase | ParameterName;
 // TODO: use openApi 3 requestBody for 'body'
 export const createParamDecorator = (inKey: 'path' | 'query' | 'body') => (
 	opts?: CreateParamDecoratorFunctionArg
-): Function => {
+): ParameterDecorator => {
 	let options;
 	if (typeof opts === 'string') {
 		options = { name: opts, in: inKey };
@@ -114,7 +114,7 @@ export interface IControllerDecoratorArgs {
  * It allows setting the basepath, resourceSchema, etc
  * @param args
  */
-export function controller(args?: IControllerDecoratorArgs): Function {
+export function controller(args?: IControllerDecoratorArgs): ClassDecorator {
 	return function(target: Function) {
 		// define new metadata props
 		Reflector.defineMetadata('davinci:openapi:controller', args, target);

--- a/packages/core/test/unit/express/decorators/context.test.ts
+++ b/packages/core/test/unit/express/decorators/context.test.ts
@@ -32,4 +32,22 @@ describe('@context()', () => {
 			type: 'context'
 		});
 	});
+
+	it('should ignore a duplicate decorator', () => {
+		class MyClass {
+			myMethod(@context() @context() context) {
+				return context;
+			}
+		}
+
+		const contextMetadata = Reflector.getMetadata('davinci:context', MyClass.prototype.constructor);
+
+		should(contextMetadata).have.length(1);
+		should(contextMetadata[0]).be.deepEqual({
+			handler: MyClass.prototype.myMethod,
+			methodName: 'myMethod',
+			index: 0,
+			type: 'context'
+		});
+	});
 });

--- a/packages/core/test/unit/express/decorators/express.test.ts
+++ b/packages/core/test/unit/express/decorators/express.test.ts
@@ -20,6 +20,24 @@ describe('express decorators', () => {
 				type: 'req'
 			});
 		});
+
+		it('should ignore a duplicate decorator', () => {
+			class MyClass {
+				myMethod(@express.req() @express.req() req) {
+					return req.accountId;
+				}
+			}
+
+			const methodParameters = Reflect.getMetadata('davinci:openapi:method-parameters', MyClass.prototype.constructor);
+
+			should(methodParameters).have.length(1);
+			should(methodParameters[0]).be.deepEqual({
+				handler: MyClass.prototype.myMethod,
+				methodName: 'myMethod',
+				index: 0,
+				type: 'req'
+			});
+		});
 	});
 
 	describe('@res()', () => {
@@ -43,7 +61,7 @@ describe('express decorators', () => {
 	});
 
 	describe('@middleware()', () => {
-		it('should decorate correctly', () => {
+		it('should decorate a method correctly', () => {
 			class MyClass {
 				@express.middleware(middlewareFn)
 				myMethod(res) {

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -183,8 +183,8 @@ describe('createRouter', () => {
 				}
 			};
 
-			route.get({ path: '/syncMethod', summary: '' })(TestController.prototype, 'syncMethod');
-			route.get({ path: '/asyncMethod', summary: '' })(TestController.prototype, 'asyncMethod');
+			route.get({ path: '/syncMethod', summary: '' })(TestController.prototype, 'syncMethod', null);
+			route.get({ path: '/asyncMethod', summary: '' })(TestController.prototype, 'asyncMethod', null);
 		});
 
 		it('should correctly coerce synchronous controller methods to return a promise', async () => {

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -20,7 +20,7 @@ import {
  * It annotates a variable as schema prop
  * @param options
  */
-export function type(options?: ITypeDecoratorOptions) {
+export function type(options?: ITypeDecoratorOptions): ClassDecorator {
 	return function(target: Function): void {
 		const metadata: ITypeDecoratorOptions = options;
 		Reflector.defineMetadata('davinci:graphql:types', metadata, target);
@@ -34,7 +34,7 @@ const DEFAULT_FIELD_OPTIONS = {};
  * It annotates a variable as schema prop
  * @param opts
  */
-export function field(opts?: IFieldDecoratorOptions | FieldDecoratorOptionsFactory) {
+export function field(opts?: IFieldDecoratorOptions | FieldDecoratorOptionsFactory): PropertyDecorator {
 	return function(prototype: object, key: string | symbol): void {
 		const optsFactory = (args: IFieldDecoratorOptionsFactoryArgs) => {
 			const options = _.merge({}, DEFAULT_FIELD_OPTIONS, typeof opts === 'function' ? opts(args) : opts);
@@ -54,7 +54,7 @@ export function field(opts?: IFieldDecoratorOptions | FieldDecoratorOptionsFacto
  * @param returnType - The return type or class of the resolver
  * @param name - Optional name
  */
-export const query = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?: string): Function => {
+export const query = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?: string): MethodDecorator => {
 	return function(prototype: object, methodName: string) {
 		const metadata: IResolverDecoratorMetadata = {
 			name,
@@ -71,7 +71,7 @@ export const query = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?: s
  * @param returnType - The return type or class of the resolver
  * @param name - Optional name
  */
-export const mutation = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?: string): Function => {
+export const mutation = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?: string): MethodDecorator => {
 	return function(prototype: object, methodName: string) {
 		const metadata: IResolverDecoratorMetadata = {
 			name,
@@ -87,7 +87,7 @@ export const mutation = (returnType: ReturnTypeFunc | ReturnTypeFuncValue, name?
  * Decorator that annotate a method parameter
  * @param options
  */
-export function arg(options?: IArgOptions): Function {
+export function arg(options?: IArgOptions): ParameterDecorator {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props
 		const methodParameters = Reflector.getMetadata('davinci:graphql:args', prototype.constructor) || [];
@@ -147,7 +147,7 @@ export function fieldResolver<T = {}>(
 	};
 }
 
-export function info() {
+export function info(): ParameterDecorator {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props
 		const methodParameters = Reflector.getMetadata('davinci:graphql:args', prototype.constructor) || [];
@@ -164,7 +164,7 @@ export function info() {
 	};
 }
 
-export function selectionSet() {
+export function selectionSet(): ParameterDecorator {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props
 		const methodParameters = Reflector.getMetadata('davinci:graphql:args', prototype.constructor) || [];
@@ -181,7 +181,7 @@ export function selectionSet() {
 	};
 }
 
-export function parent() {
+export function parent(): ParameterDecorator {
 	return function(prototype: object, methodName: string, index) {
 		// get the existing metadata props
 		const methodParameters = Reflector.getMetadata('davinci:graphql:args', prototype.constructor) || [];

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -199,8 +199,8 @@ type Stage = 'before' | 'after';
 const middleware = <TSource = any, TContext = any>(
 	middlewareFunction: ResolverMiddleware<TSource, TContext>,
 	stage: Stage = 'before'
-): Function => {
-	return function(target: Record<string, any> | Function, methodName: string) {
+): ClassDecorator & MethodDecorator => {
+	return function(target: Record<string, any> | Function, methodName?: string) {
 		const args: {
 			middlewareFunction: Function;
 			stage: Stage;
@@ -227,8 +227,6 @@ const middleware = <TSource = any, TContext = any>(
 
 		// define new metadata methods
 		Reflector.defineMetadata('davinci:graphql:middleware', middlewares, realTarget);
-
-		return target;
 	};
 };
 

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -128,8 +128,10 @@ export function fieldResolver<T = {}>(
 		// get the existing metadata props
 		const resolvers: IExternalFieldResolverDecoratorMetadata[] =
 			Reflector.getMetadata('davinci:graphql:field-resolvers', resolverOf.prototype.constructor) || [];
-		const isAlreadySet = !!_.find(resolvers, { methodName, fieldName });
-		if (isAlreadySet) return;
+		const existing = _.find(resolvers, { fieldName }) as IExternalFieldResolverDecoratorMetadata;
+		if (existing) {
+			throw new Error(`'${resolverOf.prototype.constructor.name}.${fieldName}' already resolved by ${existing.prototype.constructor.name}.${existing.methodName}`);
+		}
 
 		resolvers.unshift({
 			prototype,

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -125,15 +125,21 @@ export function fieldResolver<T = {}>(
 	returnType: ReturnTypeFuncValue
 ): MethodDecorator {
 	return function(prototype: object, methodName: string) {
-		const resolver: IExternalFieldResolverDecoratorMetadata = {
+		// get the existing metadata props
+		const resolvers: IExternalFieldResolverDecoratorMetadata[] =
+			Reflector.getMetadata('davinci:graphql:field-resolvers', resolverOf.prototype.constructor) || [];
+		const isAlreadySet = !!_.find(resolvers, { methodName, fieldName });
+		if (isAlreadySet) return;
+
+		resolvers.unshift({
 			prototype,
 			methodName,
 			resolverOf,
 			fieldName,
 			returnType,
 			handler: prototype[methodName]
-		};
-		Reflector.pushMetadata('davinci:graphql:field-resolvers', resolver, resolverOf.prototype.constructor);
+		});
+		Reflector.defineMetadata('davinci:graphql:field-resolvers', resolvers, resolverOf.prototype.constructor);
 	};
 }
 

--- a/packages/graphql/src/decorators/index.ts
+++ b/packages/graphql/src/decorators/index.ts
@@ -13,7 +13,8 @@ import {
 	FieldDecoratorOptionsFactory,
 	IFieldDecoratorOptionsFactoryArgs,
 	IResolverDecoratorMetadata,
-	ResolverMiddleware
+	ResolverMiddleware,
+	IExternalFieldResolverDecoratorMetadata
 } from '../types';
 
 /**
@@ -122,28 +123,17 @@ export function fieldResolver<T = {}>(
 	resolverOf: ClassType,
 	fieldName: keyof T,
 	returnType: ReturnTypeFuncValue
-): Function {
-	return function(prototype: object, methodName: string, index) {
-		// get the existing metadata props
-		const methodParameters =
-			Reflector.getMetadata('davinci:graphql:field-resolvers', resolverOf.prototype.constructor) || [];
-		const paramtypes = Reflector.getMetadata('design:paramtypes', prototype, methodName);
-		const isAlreadySet = !!_.find(methodParameters, { methodName, index });
-		if (isAlreadySet) return;
-
-		methodParameters.unshift({
+): MethodDecorator {
+	return function(prototype: object, methodName: string) {
+		const resolver: IExternalFieldResolverDecoratorMetadata = {
 			prototype,
 			methodName,
 			resolverOf,
-			index,
 			fieldName,
 			returnType,
-			// name,
-			// opts: options,
-			handler: prototype[methodName],
-			type: paramtypes && paramtypes[index]
-		});
-		Reflector.defineMetadata('davinci:graphql:field-resolvers', methodParameters, resolverOf.prototype.constructor);
+			handler: prototype[methodName]
+		};
+		Reflector.pushMetadata('davinci:graphql:field-resolvers', resolver, resolverOf.prototype.constructor);
 	};
 }
 

--- a/packages/graphql/src/generateSchema.ts
+++ b/packages/graphql/src/generateSchema.ts
@@ -18,7 +18,7 @@ import { GraphQLJSON } from 'graphql-type-json';
 import _fp from 'lodash/fp';
 import _ from 'lodash';
 import { Reflector } from '@davinci/reflector';
-import { IFieldDecoratorMetadata, IResolverDecoratorMetadata, OperationType } from './types';
+import { IExternalFieldResolverDecoratorMetadata, IFieldDecoratorMetadata, IResolverDecoratorMetadata, OperationType } from './types';
 import { UnionType } from './gqlTypes';
 import { createExecutableSchema } from './createControllerSchemas';
 
@@ -198,7 +198,7 @@ const createObjectFields = ({
 		resolverMetadata
 	);
 
-	const externalFieldsResolvers =
+	const externalFieldsResolvers: IExternalFieldResolverDecoratorMetadata[] =
 		Reflector.getMetadata('davinci:graphql:field-resolvers', parentType.prototype.constructor) || [];
 
 	return () => {

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -36,10 +36,16 @@ export interface IFieldDecoratorOptions {
 }
 
 export interface IResolverDecoratorMetadata {
-	name: string;
+	name?: string;
 	methodName: string;
 	returnType: any;
 	handler: Function;
+}
+
+export interface IExternalFieldResolverDecoratorMetadata extends IResolverDecoratorMetadata {
+	prototype: any;
+	resolverOf: any;
+	fieldName: any;
 }
 
 export interface IFieldDecoratorOptionsFactoryArgs {

--- a/packages/graphql/test/unit/decorators/index.test.ts
+++ b/packages/graphql/test/unit/decorators/index.test.ts
@@ -25,7 +25,7 @@ describe('decorators', () => {
 		});
 	});
 
-	describe('@graphResolver()', () => {
+	describe('@fieldResolver()', () => {
 		it('should decorate a method correctly', () => {
 			class Book {}
 			class Author {

--- a/packages/graphql/test/unit/decorators/index.test.ts
+++ b/packages/graphql/test/unit/decorators/index.test.ts
@@ -95,20 +95,13 @@ describe('decorators', () => {
 				title: string;
 			}
 
-			// @ts-ignore
-			class AuthorController {
-				@graphql.fieldResolver(Book, 'authors', [Author])
-				getBookAuthors() {}
-			}
+			class AuthorController { getBookAuthors() {} }
+			class AnotherController { getMoreAuthors() {} }
 
 			try {
-				// @ts-ignore
-				class AnotherController {
-					@graphql.fieldResolver(Book, 'authors', [Author])
-					getOtherBookAuthors() {}
-				}
+				graphql.fieldResolver(Book, 'authors', [Author])(AuthorController.prototype, 'getBookAuthors', null);
+				graphql.fieldResolver(Book, 'authors', [Author])(AnotherController.prototype, 'getMoreAuthors', null);
 				throw new Error('the above code should have thrown an error');
-
 			} catch (err) {
 				err.should.have.property('message').equal('\'Book.authors\' already resolved by AuthorController.getBookAuthors');
 			}

--- a/packages/graphql/test/unit/decorators/index.test.ts
+++ b/packages/graphql/test/unit/decorators/index.test.ts
@@ -2,7 +2,7 @@ import { Reflector } from '@davinci/reflector';
 import { graphql } from '../../../src';
 
 describe('decorators', () => {
-	describe('middleware', () => {
+	describe('@middleware()', () => {
 		it('should add the middleware functions in the right order', () => {
 			const firstMw = () => {};
 			const secondMw = () => {};
@@ -22,6 +22,62 @@ describe('decorators', () => {
 			middlewares[0].middlewareFunction.should.be.equal(firstMw);
 			middlewares[1].middlewareFunction.should.be.equal(secondMw);
 			middlewares[2].middlewareFunction.should.be.equal(thirdMw);
+		});
+	});
+
+	describe('@graphResolver()', () => {
+		it('should decorate a method correctly', () => {
+			class Book {}
+			class Author {
+				@graphql.field()
+				title: string;
+			}
+
+			// @ts-ignore
+			class AuthorController {
+				@graphql.fieldResolver(Book, 'authors', [Author])
+				getBookAuthors() {}
+			}
+
+			const middlewares = Reflector.getMetadata('davinci:graphql:field-resolvers', Book);
+			middlewares.should.have.length(1);
+			middlewares[0].should.be.deepEqual({
+				fieldName: 'authors',
+				handler: AuthorController.prototype.getBookAuthors,
+				methodName: 'getBookAuthors',
+				prototype: AuthorController.prototype,
+				resolverOf: Book,
+				returnType: [Author]
+			});
+		});
+
+		it('should ignore duplicate decorators for the same fieldName', () => {
+			class Book {}
+			class Author {
+				@graphql.field()
+				title: string;
+			}
+			class Nope {}
+
+			// @ts-ignore
+			class AuthorController {
+				// decorators of the same type are executed from bottom to top. see:
+				// https://www.typescriptlang.org/docs/handbook/decorators.html#decorator-composition
+				@graphql.fieldResolver(Book, 'authors', [Nope])
+				@graphql.fieldResolver(Book, 'authors', [Author])
+				getBookAuthors() {}
+			}
+
+			const middlewares = Reflector.getMetadata('davinci:graphql:field-resolvers', Book);
+			middlewares.should.have.length(1);
+			middlewares[0].should.be.deepEqual({
+				fieldName: 'authors',
+				handler: AuthorController.prototype.getBookAuthors,
+				methodName: 'getBookAuthors',
+				prototype: AuthorController.prototype,
+				resolverOf: Book,
+				returnType: [Author]
+			});
 		});
 	});
 });

--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -11,7 +11,7 @@ import { IPropDecoratorOptions, IPropDecoratorOptionsFactory, IPropDecoratorMeta
  * Decorate a props as mongoose schema property
  * @param options
  */
-export function prop(options?: IPropDecoratorOptions | IPropDecoratorOptionsFactory) {
+export function prop(options?: IPropDecoratorOptions | IPropDecoratorOptionsFactory): PropertyDecorator {
 	return (prototype: object, key: string): void => {
 		const optsFactory = () => (typeof options === 'function' ? options() : options);
 
@@ -27,7 +27,7 @@ export function prop(options?: IPropDecoratorOptions | IPropDecoratorOptionsFact
  * @param options
  */
 // eslint-disable-next-line no-shadow
-export function index(index, options?: any) {
+export function index(index, options?: any): ClassDecorator {
 	return (target: Function): void => {
 		Reflector.pushMetadata('davinci:mongoose:indexes', { index, options }, target);
 	};
@@ -38,7 +38,7 @@ export function index(index, options?: any) {
  * - mongoose static method is the class method is `static`
  * - mongoose method is the class method is a `prototype` method
  */
-export function method() {
+export function method(): MethodDecorator {
 	return (target: Function | object, key: string): void => {
 		const isPrototype = typeof target === 'object' && typeof target.constructor === 'function';
 		const isStatic = typeof target === 'function' && typeof target.prototype === 'object';
@@ -76,7 +76,7 @@ export interface IVirtualArgs {
  * @param name
  * @param opts
  */
-export function populate({ name, opts }: { name: string; opts: IVirtualArgs }) {
+export function populate({ name, opts }: { name: string; opts: IVirtualArgs }): PropertyDecorator {
 	return (target: object, key: string): void => {
 		const options = { ...opts, localField: key };
 		Reflector.pushMetadata('davinci:mongoose:populates', { name, options }, target.constructor);
@@ -87,7 +87,7 @@ export function populate({ name, opts }: { name: string; opts: IVirtualArgs }) {
  * Decorator that annotates a method marking it as virtual.
  * The annotated method will be used as the `getter` of the virtual
  */
-export function virtual(options?: IVirtualArgs) {
+export function virtual(options?: IVirtualArgs): MethodDecorator {
 	return (target: object, key: string): void => {
 		const handler = target[key];
 		if (options?.ref && typeof handler === 'function') {
@@ -103,7 +103,7 @@ export function virtual(options?: IVirtualArgs) {
 /**
  * Decorator that annotates a schema, allowing to pass options to the mongoose 'Schema' constructor
  */
-export function schema(options?: SchemaOptions) {
+export function schema(options?: SchemaOptions): ClassDecorator {
 	return (target: Function): void => {
 		Reflector.defineMetadata('davinci:mongoose:schemaOptions', options, target);
 	};


### PR DESCRIPTION
This PR adds the correct TypeScript decorator types, to improve type-safety and understandability of the codebase.

It also slightly refactors the GraphQL `@fieldResolver` decorator to improve the behaviour slightly:
- It no longer has the wrong signature (previously was the `ParameterDecorator` signature)
- It now has an interface that defines the actual metadata that we capture
- It now ensures the fieldResolver doesn't clash with another fieldResolver on the same class+property

I also added a couple of tests for verifying duplicate decorator functionality on the express decorators