### PR TITLE
fix: default basepath to / instead of resource name

### DIFF
--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -402,7 +402,7 @@ function createRouterAndSwaggerDoc(...options): Router | DaVinciExpress {
 
 	// get controller metadata
 	const metadata: IControllerDecoratorArgs = Reflector.getMetadata('davinci:openapi:controller', Controller) || {};
-	const basepath = metadata.basepath || `/${resourceName}`;
+	const basepath = metadata.basepath || '/';
 	const { resourceSchema } = metadata;
 	const { additionalSchemas } = metadata;
 

--- a/packages/core/src/route/openapi/openapiDocs.ts
+++ b/packages/core/src/route/openapi/openapiDocs.ts
@@ -5,6 +5,7 @@
 
 import Debug from 'debug';
 import _ from 'lodash';
+import path from 'path';
 import Resource from './Resource';
 
 const debug = new Debug('davinci:openapi');
@@ -72,12 +73,10 @@ export const generateFullSwagger = opts => {
 
 		// add paths
 		_.each(resource.paths, (resourcePath, pathName) => {
-			const trimmedBasePath = _.trim(resource.basePath, '/');
-			let fullPath = `/${trimmedBasePath}${pathName}`;
-			if (pathName === '/') fullPath = `/${trimmedBasePath}`;
-			const path = sanitiseResourcePath(resourcePath);
-			if (!_.isEmpty(path)) {
-				fullSwagger.paths[fullPath] = path;
+			const fullPath = _.trimEnd(path.join('/', resource.basePath || '', pathName || ''), '/');
+			const sanitisedPath = sanitiseResourcePath(resourcePath);
+			if (!_.isEmpty(sanitisedPath)) {
+				fullSwagger.paths[fullPath] = sanitisedPath;
 			}
 		});
 	});

--- a/packages/core/src/route/openapi/openapiDocs.ts
+++ b/packages/core/src/route/openapi/openapiDocs.ts
@@ -73,10 +73,10 @@ export const generateFullSwagger = opts => {
 
 		// add paths
 		_.each(resource.paths, (resourcePath, pathName) => {
-			const fullPath = _.trimEnd(path.join('/', resource.basePath || '', pathName || ''), '/');
-			const sanitisedPath = sanitiseResourcePath(resourcePath);
-			if (!_.isEmpty(sanitisedPath)) {
-				fullSwagger.paths[fullPath] = sanitisedPath;
+			const pathObject = sanitiseResourcePath(resourcePath);
+			if (!_.isEmpty(pathObject)) {
+				const fullPath = _.trim(path.join(resource.basePath, pathName), '/');
+				fullSwagger.paths[`/${fullPath}`] = pathObject;
 			}
 		});
 	});

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -52,6 +52,7 @@ describe('createRouter', () => {
 		it('should have correct routes when controller has no decorator', () => {
 			const app = express();
 
+			// no controller, so 'basepath' should default to '/'
 			class GreetController {
 				@route.get({ path: '/hello', summary: 'Oh hello!' })
 				hello() {}
@@ -59,17 +60,18 @@ describe('createRouter', () => {
 			createRouter({ Controller: GreetController, router: app });
 			const swagger = openapiDocs.generateFullSwagger({});
 
-			const expectedPath = '/greet/hello';
+			const expectedPath = '/hello';
 			const expressPath = app._router.stack[2].route.path;
+			console.log(JSON.stringify(swagger.paths,null,2));
 			const openapiPath = Object.keys(swagger.paths)[0];
-			expressPath.should.eql(expectedPath);
-			openapiPath.should.eql(expectedPath);
+			expressPath.should.eql(expectedPath, 'express path');
+			openapiPath.should.eql(expectedPath, 'openAPI path');
 		});
 
 		it('should have correct routes when no basepath defined on the controller', () => {
 			const app = express();
 
-			@route.controller() // derives 'basepath' from controller name (ie. 'greet')
+			@route.controller() // 'basepath' should default to '/'
 			class GreetController {
 				@route.get({ path: '/hello', summary: 'Oh hello!' })
 				hello() {}
@@ -77,11 +79,11 @@ describe('createRouter', () => {
 			createRouter({ Controller: GreetController, router: app });
 			const swagger = openapiDocs.generateFullSwagger({});
 
-			const expectedPath = '/greet/hello';
+			const expectedPath = '/hello';
 			const expressPath = app._router.stack[2].route.path;
 			const openapiPath = Object.keys(swagger.paths)[0];
-			expressPath.should.eql(expectedPath);
-			openapiPath.should.eql(expectedPath);
+			expressPath.should.eql(expectedPath, 'express path');
+			openapiPath.should.eql(expectedPath, 'openAPI path');
 		});
 
 		it('should have correct routes when basepath IS defined on the controller', () => {
@@ -98,8 +100,8 @@ describe('createRouter', () => {
 			const expectedPath = '/foo/hello';
 			const expressPath = app._router.stack[2].route.path;
 			const openapiPath = Object.keys(swagger.paths)[0];
-			expressPath.should.eql(expectedPath);
-			openapiPath.should.eql(expectedPath);
+			expressPath.should.eql(expectedPath, 'express path');
+			openapiPath.should.eql(expectedPath, 'openAPI path');
 		});
 
 		it('should succeed even with invalid controller definitions', done => {
@@ -121,7 +123,7 @@ describe('createRouter', () => {
 				.have.property('stack')
 				.of.length(5);
 			router.stack[0].should.have.property('route');
-			router.stack[0].route.should.have.property('path').equal('/param/:id');
+			router.stack[0].route.should.have.property('path').equal('/:id');
 			router.stack[0].route.should.have.property('methods').deepEqual({ delete: true });
 			done();
 		});

--- a/packages/core/test/unit/route/openapi/openapiDocs.test.ts
+++ b/packages/core/test/unit/route/openapi/openapiDocs.test.ts
@@ -255,5 +255,80 @@ describe('openapiDocs', () => {
 				}
 			});
 		});
+
+		it('should generate the correct route without a basepath', () => {
+			openapiDocs.addResource(
+				{
+					paths: {
+						'/bar': { get: { operationId: 'operationId' } }
+					}
+				},
+				'customer' // resourceName
+				// <- no basepath
+			);
+			const swagger = openapiDocs.generateFullSwagger({});
+
+			swagger.paths.should.have.property('/customer/bar');
+		});
+
+		it('should generate the correct route with a basepath', () => {
+			openapiDocs.addResource(
+				{
+					paths: {
+						'/bar': { get: { operationId: 'operationId' } }
+					}
+				},
+				'customer', // resourceName
+				'foo' // basepath without leading slash
+			);
+			const swagger = openapiDocs.generateFullSwagger({});
+
+			swagger.paths.should.have.property('/foo/bar');
+		});
+
+		it('should generate the correct route with basepath and "/" path', () => {
+			openapiDocs.addResource(
+				{
+					paths: {
+						'/': { get: { operationId: 'operationId' } }
+					}
+				},
+				'customer', // resourceName
+				'foo' // basepath without leading slash
+			);
+			const swagger = openapiDocs.generateFullSwagger({});
+
+			swagger.paths.should.have.property('/foo');
+		});
+
+		it('should generate the correct route with basepath with a leading slash', () => {
+			openapiDocs.addResource(
+				{
+					paths: {
+						'/baz': { get: { operationId: 'operationId' } }
+					}
+				},
+				'customer', // resourceName
+				'/foo' // basepath with leading slash
+			);
+			const swagger = openapiDocs.generateFullSwagger({});
+
+			swagger.paths.should.have.property('/foo/baz');
+		});
+
+		it('should generate the correct route with "/" basepath and "/" path', () => {
+			openapiDocs.addResource(
+				{
+					paths: {
+						'/': { get: { operationId: 'operationId' } }
+					}
+				},
+				'customer', // resourceName
+				'/' // basepath with leading slash
+			);
+			const swagger = openapiDocs.generateFullSwagger({});
+
+			swagger.paths.should.have.property('/');
+		});
 	});
 });


### PR DESCRIPTION
This is an update to the previous `basepath` PR #84. 

After discussing with @pierissimo, it was decided that defaulting `basepath` to `resourceName` when it wasn't defined was not the preferable solution. Instead, we now default the `basepath` to `/` if it wasn't defined.

This PR makes that change while also ensuring the Swagger Docs generation is fixed to be consistent (which is what issue #31 originally reported). 

It also adds even more unit tests, so we can be extra sure that it is now behaving as expected :) 