### PR TITLE
chore: test against MongoDB 5.0 in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
       - checkout_and_test:
           matrix:
             parameters:
-              mongo-version: ["4.2", "4.4"]
+              mongo-version: ["4.4", "5"]
               node-version: ["12", "14", "16"]
       - publish:
           requires:


### PR DESCRIPTION
This PR adds MongoDB 5.0 to the CircleCI test matrix and removes MongoDB 4.2 (but leaves 4.4).