### PR TITLE
Fix: Build path with path.join is error prone depending OS

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.1.1.tgz",
+			"integrity": "sha512-eg+YvFaqd65TL860ZkZv8b+//VlqFrWgB2Mz6P8ZTBg++zq7x094RPtb1kJhbjonszPLJaL7Njjzg5hXTZMdFg==",
 			"requires": {
 				"reflect-metadata": "0.1.13"
 			}
@@ -599,6 +599,11 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
+		},
+		"url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"utils-merge": {
 			"version": "1.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
 		"bluebird": "^3.7.2",
 		"debug": "^4.1.1",
 		"lodash": "^4.17.19",
-		"require-dir": "^1.2.0"
+		"require-dir": "^1.2.0",
+		"url-join": "^4.0.1"
 	},
 	"peerDependencies": {
 		"express": "^4.16.4",

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -11,7 +11,7 @@ import express, { NextFunction, Response, Router } from 'express';
 import _ from 'lodash';
 import _fp from 'lodash/fp';
 import Promise from 'bluebird';
-import path from 'path';
+import urlJoin from 'url-join';
 import { ClassType, Reflector } from '@davinci/reflector';
 import { DaVinciRequest, IHeaderDecoratorMetadata } from '../express/types';
 import { NotImplemented, BadRequest } from '../errors/httpErrors';
@@ -433,7 +433,7 @@ function createRouterAndSwaggerDoc(...options): Router | DaVinciExpress {
 
 	// add them to the router
 	routes.forEach(route => {
-		const routePath = path.join(basepath, route.path);
+		const routePath = urlJoin(basepath, route.path);
 		return router[route.method](routePath, ...route.handlers);
 	});
 

--- a/packages/core/src/route/openapi/openapiDocs.ts
+++ b/packages/core/src/route/openapi/openapiDocs.ts
@@ -5,7 +5,7 @@
 
 import Debug from 'debug';
 import _ from 'lodash';
-import path from 'path';
+import urlJoin from 'url-join';
 import Resource from './Resource';
 
 const debug = new Debug('davinci:openapi');
@@ -75,7 +75,7 @@ export const generateFullSwagger = opts => {
 		_.each(resource.paths, (resourcePath, pathName) => {
 			const pathObject = sanitiseResourcePath(resourcePath);
 			if (!_.isEmpty(pathObject)) {
-				const fullPath = _.trim(path.join(resource.basePath, pathName), '/');
+				const fullPath = _.trim(urlJoin(resource.basePath, pathName), '/');
 				fullSwagger.paths[`/${fullPath}`] = pathObject;
 			}
 		});

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -4,6 +4,42 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@davinci/core": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.5.4.tgz",
+			"integrity": "sha512-QJQ0NwGQMKz/G15qw4n4hOUGUX54Lm2x9bTVA0y5tsFLg0ntyDqVsCV0OjkL6RckQ5AifEzLOGDE1w1WZYMVaQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@davinci/reflector": "^1.0.2",
+				"@godaddy/terminus": "^4.1.0",
+				"ajv": "^7.0.0",
+				"ajv-formats": "^1.5.1",
+				"bluebird": "^3.5.0",
+				"debug": "^4.1.1",
+				"lodash": "^4.17.19",
+				"require-dir": "^1.2.0",
+				"swagger-ui-express": "^4.0.7"
+			}
+		},
+		"@davinci/reflector": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
+			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
+			"requires": {
+				"reflect-metadata": "0.1.13"
+			}
+		},
+		"@godaddy/terminus": {
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.7.2.tgz",
+			"integrity": "sha512-hiTKQUXcp84uvnr57/mFK/0xUUuzpVJsCs0hsulk5+6mA+U/drewHG58QDgoCFuWjo8ceumFP7uvr4PpmFYG9g==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"stoppable": "^1.1.0"
+			}
+		},
 		"@types/bson": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
@@ -28,6 +64,29 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.23.tgz",
 			"integrity": "sha512-pkKXgf96TELUhrc8C01J0e+If5qb0WqF+WF09FbCINywIk+iUEQgMlA8IxgdZ79qQ88Bljw+9NcqwvWGXknWDw==",
 			"dev": true
+		},
+		"ajv": {
+			"version": "7.2.4",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
+			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-formats": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
+			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"ajv": "^7.0.0"
+			}
 		},
 		"bl": {
 			"version": "2.2.1",
@@ -70,6 +129,13 @@
 			"integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
 			"dev": true
 		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"optional": true
+		},
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -81,6 +147,13 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"optional": true
 		},
 		"kareem": {
 			"version": "2.3.2",
@@ -205,6 +278,13 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
+			"optional": true
+		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -228,11 +308,30 @@
 				}
 			}
 		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
 			"dev": true
+		},
+		"require-dir": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
+			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
+			"dev": true,
+			"optional": true
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"optional": true
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -294,6 +393,13 @@
 				"memory-pager": "^1.0.2"
 			}
 		},
+		"stoppable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+			"dev": true,
+			"optional": true
+		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -311,6 +417,23 @@
 				}
 			}
 		},
+		"swagger-ui-dist": {
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
+			"integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg==",
+			"dev": true,
+			"optional": true
+		},
+		"swagger-ui-express": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+			"integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"swagger-ui-dist": "^3.18.1"
+			}
+		},
 		"tslib": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -322,6 +445,16 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
 			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
+		},
+		"uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -4,42 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@davinci/core": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.5.4.tgz",
-			"integrity": "sha512-QJQ0NwGQMKz/G15qw4n4hOUGUX54Lm2x9bTVA0y5tsFLg0ntyDqVsCV0OjkL6RckQ5AifEzLOGDE1w1WZYMVaQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"@davinci/reflector": "^1.0.2",
-				"@godaddy/terminus": "^4.1.0",
-				"ajv": "^7.0.0",
-				"ajv-formats": "^1.5.1",
-				"bluebird": "^3.5.0",
-				"debug": "^4.1.1",
-				"lodash": "^4.17.19",
-				"require-dir": "^1.2.0",
-				"swagger-ui-express": "^4.0.7"
-			}
-		},
-		"@davinci/reflector": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@davinci/reflector/-/reflector-1.0.2.tgz",
-			"integrity": "sha512-ZO+ZpfJ0xxoxIyYtGLzTawrf23xACK6KjLBjZOqzai6A47xIb67i4l9/kEOlZDIXZsvw1o6yoFBzC0hYVOfSdQ==",
-			"requires": {
-				"reflect-metadata": "0.1.13"
-			}
-		},
-		"@godaddy/terminus": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.7.2.tgz",
-			"integrity": "sha512-hiTKQUXcp84uvnr57/mFK/0xUUuzpVJsCs0hsulk5+6mA+U/drewHG58QDgoCFuWjo8ceumFP7uvr4PpmFYG9g==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"stoppable": "^1.1.0"
-			}
-		},
 		"@types/bson": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
@@ -64,29 +28,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.23.tgz",
 			"integrity": "sha512-pkKXgf96TELUhrc8C01J0e+If5qb0WqF+WF09FbCINywIk+iUEQgMlA8IxgdZ79qQ88Bljw+9NcqwvWGXknWDw==",
 			"dev": true
-		},
-		"ajv": {
-			"version": "7.2.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			}
-		},
-		"ajv-formats": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
-			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"ajv": "^7.0.0"
-			}
 		},
 		"bl": {
 			"version": "2.2.1",
@@ -129,13 +70,6 @@
 			"integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
 			"dev": true
 		},
-		"fast-deep-equal": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"optional": true
-		},
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -147,13 +81,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
-		},
-		"json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"optional": true
 		},
 		"kareem": {
 			"version": "2.3.2",
@@ -278,13 +205,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
-		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
-			"optional": true
-		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -308,30 +228,11 @@
 				}
 			}
 		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-		},
 		"regexp-clone": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
 			"integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
 			"dev": true
-		},
-		"require-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
-			"dev": true,
-			"optional": true
-		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
-			"optional": true
 		},
 		"require_optional": {
 			"version": "1.0.1",
@@ -393,13 +294,6 @@
 				"memory-pager": "^1.0.2"
 			}
 		},
-		"stoppable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-			"dev": true,
-			"optional": true
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -417,23 +311,6 @@
 				}
 			}
 		},
-		"swagger-ui-dist": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
-			"integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg==",
-			"dev": true,
-			"optional": true
-		},
-		"swagger-ui-express": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
-			"integrity": "sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"swagger-ui-dist": "^3.18.1"
-			}
-		},
 		"tslib": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -445,16 +322,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
 			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
 			"dev": true
-		},
-		"uri-js": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"punycode": "^2.1.0"
-			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",


### PR DESCRIPTION
Use path.join to concatenatepath creates wrong api paths when davinci is used in windows OS.

So that: 

-  url.resolve() is the same as path.join() but it's deprecated <https://nodejs.org/api/url.html#url_url_resolve_from_to>
-  Davinci uses url-join library to join path

![Capture](https://user-images.githubusercontent.com/11947258/134536931-f8586159-c01b-4cfa-b6d1-4b85c0b38102.PNG)


