### PR TITLE
feat: adding port configuration on davinci options

### DIFF
--- a/packages/core/src/createApp.ts
+++ b/packages/core/src/createApp.ts
@@ -26,7 +26,7 @@ interface HealthChecksOptions {
 
 export interface DaVinciOptions {
 	version?: string | number;
-	port?: string | number;
+	port?: number;
 	boot?: {
 		dirPath?: string;
 	};

--- a/packages/core/src/createApp.ts
+++ b/packages/core/src/createApp.ts
@@ -26,6 +26,7 @@ interface HealthChecksOptions {
 
 export interface DaVinciOptions {
 	version?: string | number;
+	port?: string | number;
 	boot?: {
 		dirPath?: string;
 	};
@@ -163,9 +164,10 @@ export const createApp = (...args: CreateAppArgs): Promise<DaVinciExpress> => {
 		debug('configure terminus');
 		await configureTerminus(app, options.healthChecks);
 
+		const port = options.port || config.PORT;
 		await new Promise<void>(resolve =>
-			server.listen(config.PORT, () => {
-				console.log(`--- Server listening on ${config.PORT}`);
+			server.listen(port, () => {
+				console.log(`--- Server listening on ${port}`);
 				resolve();
 			})
 		);

--- a/packages/core/test/unit/createApp.test.ts
+++ b/packages/core/test/unit/createApp.test.ts
@@ -144,5 +144,16 @@ describe('createApp', () => {
 			await app.start();
 			should(app.server).have.property('listen');
 		});
+		it('Should successfully configure a port with middleware', async () => {
+			const myApp = express();
+			const middlewares = app => {
+				should(app).have.property('use');
+			};
+			const myOptions = { port: 8080 };
+			app = await createApp(myApp, myOptions, middlewares);
+			await app.start();
+			should(app.server).have.property('listen');
+			should(app.server.address().port).equal(8080);
+		});
 	});
 });

--- a/packages/core/test/unit/createApp.test.ts
+++ b/packages/core/test/unit/createApp.test.ts
@@ -144,7 +144,7 @@ describe('createApp', () => {
 			await app.start();
 			should(app.server).have.property('listen');
 		});
-		it('Should successfully configure a port with middleware', async () => {
+		it('Should successfully configure a http express app with a custom port', async () => {
 			const myApp = express();
 			const middlewares = app => {
 				should(app).have.property('use');


### PR DESCRIPTION
This PR add a new attribute `port` to DaVinciOptions. The reason for this is to be able to define a port to listen over the options given to the createApp method.

I'm suggesting/doing this change because not always env vars are free to be used. To give you more context, 3D team is trying to create an API that will run alongside a Bucket Closer service, but we had a issue, the existing service already use the `PORT` env var and DaVinci is trying to use the same port, so defining the port trough options parameter would solve this and make DaVinci more flexible. 