### PR TITLE
Fix: npm security updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8543,18 +8543,26 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.4",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
+				"bn.js": "^4.11.9",
+				"brorand": "^1.1.0",
 				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"hmac-drbg": "^1.0.1",
+				"inherits": "^2.0.4",
+				"minimalistic-assert": "^1.0.1",
+				"minimalistic-crypto-utils": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.12.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"dev": true
+				}
 			}
 		},
 		"emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12497,9 +12497,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
 		"lodash._reinterpolate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20011,9 +20011,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
 		},
 		"yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5578,9 +5578,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -9980,7 +9980,6 @@
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -10185,8 +10184,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -10276,8 +10274,7 @@
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -17733,9 +17733,9 @@
 			}
 		},
 		"ssri": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-			"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+			"integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
 			"dev": true,
 			"requires": {
 				"figgy-pudding": "^3.5.1"


### PR DESCRIPTION
Bump following vulnerable packages:

* acorn, lodash, elliptic, ssri and y18n

All of them are minor versions. Reviewed changelog and no breaking changes.

Pending a few high ones that can't be addressed without replacing vuepress. I will raise an exception for them.