### PR TITLE
Fix: Allow virtual decorator on properties

### DIFF
--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -87,7 +87,7 @@ export function populate({ name, opts }: { name: string; opts: IVirtualArgs }): 
  * Decorator that annotates a method marking it as virtual.
  * The annotated method will be used as the `getter` of the virtual
  */
-export function virtual(options?: IVirtualArgs): MethodDecorator {
+export function virtual(options?: IVirtualArgs): MethodDecorator & PropertyDecorator {
 	return (target: object, key: string): void => {
 		const handler = target[key];
 		if (options?.ref && typeof handler === 'function') {

--- a/packages/mongoose/test/unit/decorators/index.test.ts
+++ b/packages/mongoose/test/unit/decorators/index.test.ts
@@ -33,4 +33,33 @@ describe('mgoose decorators', () => {
 			should(propsMetadata).be.deepEqual({ timestamps: true });
 		});
 	});
+
+	describe('@mgoose.virtual()', () => {
+		it('should decorate property correctly', () => {
+			@mgoose.schema({ timestamps: true })
+			class Customer {
+				@mgoose.virtual()
+				@mgoose.prop({ required: false })
+				firstname: string;
+			}
+
+			const propsMetadata = Reflect.getMetadata('davinci:mongoose:virtuals', Customer);
+			should(propsMetadata[0].name).be.equal('firstname');
+			should(propsMetadata[0].handler).be.undefined();
+		});
+
+		it('should decorate method correctly', () => {
+			@mgoose.schema({ timestamps: true })
+			class Customer {
+				@mgoose.virtual()
+				@mgoose.prop({ required: false })
+				firstname(): string { return 'firstName' };
+			}
+
+			const propsMetadata = Reflect.getMetadata('davinci:mongoose:virtuals', Customer);
+			should(propsMetadata[0].name).be.equal('firstname');
+			should(propsMetadata[0].handler).not.be.undefined();
+		});
+	});
+
 });


### PR DESCRIPTION
Changes from https://github.com/HPInc/davinci/pull/83 cause build issues when using virtual to decorate a property. 

Adding return type as PropertyDecorator to fix it. Tested locally and added a test to cover this behavior.