### PR TITLE
Chore: upgrade vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9593,9 +9593,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.7",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-			"integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
 			"dev": true
 		},
 		"for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13902,9 +13902,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.6",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-			"integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
@@ -18827,9 +18827,9 @@
 			}
 		},
 		"url-parse": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-			"integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+			"version": "1.5.9",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.9.tgz",
+			"integrity": "sha512-HpOvhKBvre8wYez+QhHcYiVvVmeF6DVnuSOOPhe3cTum3BnqHhvKaZm8FU5yTiOu/Jut2ZpB2rA/SbBA1JIGlQ==",
 			"dev": true,
 			"requires": {
 				"querystringify": "^2.1.1",


### PR DESCRIPTION
Bump url-parse, follow-redirects & node-fetch