### PR TITLE
feat(reflector): using @plumier/reflector

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 singleQuote: true
 printWidth: 120
 arrowParens: avoid
+trailingComma: none

--- a/examples/next/package-lock.json
+++ b/examples/next/package-lock.json
@@ -1,14 +1,15 @@
 {
-	"name": "@davinci/example-rest",
+	"name": "@davinci/example-next",
 	"version": "0.15.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@davinci/example-rest",
+			"name": "@davinci/example-next",
 			"version": "0.15.9",
 			"license": "MIT",
 			"dependencies": {
+				"@davinci/core": "^1.9.1",
 				"@davinci/mongoose": "^0.17.9",
 				"debug": "^4.1.1",
 				"express": "4.16.4",
@@ -27,7 +28,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.9.1.tgz",
 			"integrity": "sha512-6h7ps4pF2fc7Q/q+1HoYehkNAIMESxyx4vSGy4MFlk2xniyiCRra3diuEvom7Yj/vPWhkfExJZV3jVaG/E5tVw==",
-			"optional": true,
 			"dependencies": {
 				"@davinci/reflector": "^1.1.1",
 				"@godaddy/terminus": "^4.1.0",
@@ -52,8 +52,7 @@
 		"node_modules/@davinci/core/node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"optional": true
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"node_modules/@davinci/mongoose": {
 			"version": "0.17.9",
@@ -90,7 +89,6 @@
 			"version": "4.10.2",
 			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.10.2.tgz",
 			"integrity": "sha512-xzNSk6yL3tbeD/vtmHlrBbxflmmbdBKT89rM4b10H5LeaBjBFgG6CsDPTb6CdZHdwipZl1Rxn5RDH5UbCLf8Qw==",
-			"optional": true,
 			"dependencies": {
 				"stoppable": "^1.1.0"
 			}
@@ -226,7 +224,6 @@
 			"version": "7.2.4",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
 			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"optional": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -242,7 +239,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-2.0.1.tgz",
 			"integrity": "sha512-hGH2npS6nUdBr61gf3rcG8R04DwwgQsdt6goZGmaZHYRHtLF948Emsdta/bcP9AD6/X1jnHm9lMbgujOQG7W6A==",
-			"optional": true,
 			"peerDependencies": {
 				"ajv": "^7.0.0"
 			}
@@ -251,7 +247,6 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
 			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"optional": true,
 			"dependencies": {
 				"ajv": "^7.0.0"
 			},
@@ -513,8 +508,7 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"optional": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/finalhandler": {
 			"version": "1.1.1",
@@ -608,8 +602,7 @@
 		"node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"optional": true
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/kareem": {
 			"version": "2.3.2",
@@ -887,7 +880,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"optional": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -958,7 +950,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
 			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
-			"optional": true,
 			"engines": {
 				"node": "*"
 			}
@@ -967,7 +958,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1099,7 +1089,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-			"optional": true,
 			"engines": {
 				"node": ">=4",
 				"npm": ">=6"
@@ -1218,7 +1207,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"optional": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -1226,8 +1214,7 @@
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"optional": true
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -1265,7 +1252,6 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/@davinci/core/-/core-1.9.1.tgz",
 			"integrity": "sha512-6h7ps4pF2fc7Q/q+1HoYehkNAIMESxyx4vSGy4MFlk2xniyiCRra3diuEvom7Yj/vPWhkfExJZV3jVaG/E5tVw==",
-			"optional": true,
 			"requires": {
 				"@davinci/reflector": "^1.1.1",
 				"@godaddy/terminus": "^4.1.0",
@@ -1283,8 +1269,7 @@
 				"bluebird": {
 					"version": "3.7.2",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-					"optional": true
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				}
 			}
 		},
@@ -1319,7 +1304,6 @@
 			"version": "4.10.2",
 			"resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.10.2.tgz",
 			"integrity": "sha512-xzNSk6yL3tbeD/vtmHlrBbxflmmbdBKT89rM4b10H5LeaBjBFgG6CsDPTb6CdZHdwipZl1Rxn5RDH5UbCLf8Qw==",
-			"optional": true,
 			"requires": {
 				"stoppable": "^1.1.0"
 			}
@@ -1452,7 +1436,6 @@
 			"version": "7.2.4",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
 			"integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-			"optional": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -1464,14 +1447,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-2.0.1.tgz",
 			"integrity": "sha512-hGH2npS6nUdBr61gf3rcG8R04DwwgQsdt6goZGmaZHYRHtLF948Emsdta/bcP9AD6/X1jnHm9lMbgujOQG7W6A==",
-			"optional": true,
 			"requires": {}
 		},
 		"ajv-formats": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-1.6.1.tgz",
 			"integrity": "sha512-4CjkH20If1lhR5CGtqkrVg3bbOtFEG80X9v6jDOIUhbzzbB+UzPBGy8GQhUNVZ0yvMHdMpawCOcy5ydGMsagGQ==",
-			"optional": true,
 			"requires": {
 				"ajv": "^7.0.0"
 			}
@@ -1684,8 +1665,7 @@
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"optional": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"finalhandler": {
 			"version": "1.1.1",
@@ -1763,8 +1743,7 @@
 		"json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"optional": true
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"kareem": {
 			"version": "2.3.2",
@@ -1960,8 +1939,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"optional": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"qs": {
 			"version": "6.5.2",
@@ -2016,14 +1994,12 @@
 		"require-dir": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
-			"optional": true
+			"integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA=="
 		},
 		"require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"optional": true
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -2138,8 +2114,7 @@
 		"stoppable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-			"optional": true
+			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
 		},
 		"string_decoder": {
 			"version": "1.1.1",
@@ -2211,7 +2186,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"optional": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -2219,8 +2193,7 @@
 		"url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"optional": true
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@davinci/example-rest",
+	"name": "@davinci/example-next",
 	"version": "0.15.9",
 	"private": true,
 	"description": "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	},
 	"scripts": {
 		"postinstall": "npm run bootstrap",
-		"build": "lerna run build",
+		"build": "lerna run build --ignore '@davinci/example*'",
 		"test": "lerna run test",
 		"cover": "lerna run cover",
 		"bootstrap": "lerna bootstrap --ignore '@davinci/example*'",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
 	},
 	"scripts": {
 		"postinstall": "npm run bootstrap",
-		"build": "lerna run build --ignore '@davinci/example*'",
+		"build": "lerna run build",
 		"test": "lerna run test",
 		"cover": "lerna run cover",
-		"bootstrap": "lerna bootstrap --ignore '@davinci/example*'",
+		"bootstrap": "lerna bootstrap",
 		"bump": "lerna publish",
 		"docs:dev": "vuepress dev docs",
 		"docs:build": "vuepress build docs --debug",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"build": "lerna run build",
 		"test": "lerna run test",
 		"cover": "lerna run cover",
-		"bootstrap": "lerna bootstrap",
+		"bootstrap": "lerna bootstrap --ignore '@davinci/example*'",
 		"bump": "lerna publish",
 		"docs:dev": "vuepress dev docs",
 		"docs:build": "vuepress build docs --debug",

--- a/packages/reflector/.eslintrc
+++ b/packages/reflector/.eslintrc
@@ -1,0 +1,3 @@
+{
+	"extends": "../../.eslintrc"
+}

--- a/packages/reflector/README.md
+++ b/packages/reflector/README.md
@@ -1,0 +1,4 @@
+## @davinci/reflector
+
+Internal metadata reflection package.
+It proxies methods and decoratos of the awesome @plumier/reflect library

--- a/packages/reflector/package-lock.json
+++ b/packages/reflector/package-lock.json
@@ -1,0 +1,59 @@
+{
+	"name": "@davinci/reflector",
+	"version": "1.1.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@plumier/reflect": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@plumier/reflect/-/reflect-1.0.6.tgz",
+			"integrity": "sha512-T/wkxlrXZ3qJV07YFC67I5HXlI1E2D7Kmq7skZxu7KEoqjMWrTEpvug2mJ7tze0WeDtPerl9C9m55lk+0+Ipyw==",
+			"requires": {
+				"@types/acorn": "4.0.6",
+				"acorn": "8.5.0",
+				"reflect-metadata": "^0.1.13"
+			}
+		},
+		"@types/acorn": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
+			"integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.51",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
+		},
+		"@types/mocha": {
+			"version": "5.2.7",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"tslib": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "4.3.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+			"integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+			"dev": true
+		}
+	}
+}

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@davinci/reflector",
+	"version": "1.1.1",
+	"description": "Utility module used for metadata reflection",
+	"main": "build/index.js",
+	"types": "build/index.d.ts",
+	"scripts": {
+		"build": "tsc -p ./tsconfig.release.json",
+		"eslint": "../../node_modules/eslint/bin/eslint.js --color --c .eslintrc 'src/**/*.ts'",
+		"pretest": "npm run eslint && npm run build",
+		"test": "mocha --exit",
+		"cover": "nyc npm test"
+	},
+	"author": "HP",
+	"license": "MIT",
+	"dependencies": {
+		"@plumier/reflect": "1.0.6"
+	}
+}

--- a/packages/reflector/src/index.ts
+++ b/packages/reflector/src/index.ts
@@ -1,0 +1,7 @@
+/*
+ * © Copyright 2020 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+export * from './reflect';
+export * from './shared-types';

--- a/packages/reflector/src/reflect.ts
+++ b/packages/reflector/src/reflect.ts
@@ -11,5 +11,5 @@ export {
 	decorateParameter,
 	decorate,
 	ObjectReflection,
-	ClassReflection,
+	ClassReflection
 } from '@plumier/reflect';

--- a/packages/reflector/src/reflect.ts
+++ b/packages/reflector/src/reflect.ts
@@ -1,0 +1,15 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+export {
+	reflect,
+	decorateClass,
+	decorateMethod,
+	decorateProperty,
+	decorateParameter,
+	decorate,
+	ObjectReflection,
+	ClassReflection,
+} from '@plumier/reflect';

--- a/packages/reflector/src/shared-types.ts
+++ b/packages/reflector/src/shared-types.ts
@@ -1,0 +1,23 @@
+/*
+ * © Copyright 2020 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+export type Maybe<T> = null | undefined | T;
+
+export interface ClassType<T = any> {
+	new (...args: any[]): T;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RecursiveArray<TValue> extends Array<RecursiveArray<TValue> | TValue> {}
+
+export type TypeValue = ClassType | Function | object | boolean;
+export type ReturnTypeFuncValue = TypeValue | RecursiveArray<TypeValue>;
+export type ReturnTypeFunc = (returns?: void) => ReturnTypeFuncValue;
+
+export type TypeValueFactory = (type?: void) => TypeValue;
+export type ClassTypeResolver = (of?: void) => ClassType;
+
+
+export type Thunk<T> = (() => T) | T;

--- a/packages/reflector/test/mocha.opts
+++ b/packages/reflector/test/mocha.opts
@@ -1,0 +1,10 @@
+--color
+--reporter spec
+--ui bdd
+--recursive
+--bail
+--check-leaks
+--globals sinon,_
+--require ts-node/register
+--require source-map-support/register
+test/**/*.{js,ts}

--- a/packages/reflector/test/unit/reflect.test.ts
+++ b/packages/reflector/test/unit/reflect.test.ts
@@ -1,0 +1,74 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+import { reflect, decorate } from '../../src';
+import should from 'should';
+
+describe('reflect', () => {
+	describe('reflect', () => {
+		it('should return a representation of the class, with decorators, methods and parameters', () => {
+			// create custom decorator
+			function cache(duration: number) {
+				return decorate({ type: 'cache', duration });
+			}
+
+			function cachedParam() {
+				return decorate({ type: 'cachedParam' });
+			}
+
+			@cache(5)
+			class MyAwesomeClass {
+				@cache(1) // use it like usual decorator
+				awesome(@cachedParam() myParam: string) {
+					console.log(myParam);
+				}
+			}
+
+			const reflected = reflect(MyAwesomeClass);
+			should(reflected).match({
+				kind: 'Class',
+				name: 'MyAwesomeClass',
+				decorators: [
+					{
+						type: 'cache',
+						duration: 5,
+					},
+				],
+				methods: [
+					{
+						kind: 'Method',
+						name: 'awesome',
+						parameters: [
+							{
+								kind: 'Parameter',
+								name: 'myParam',
+								decorators: [
+									{
+										type: 'cachedParam',
+									},
+								],
+								fields: 'myParam',
+								index: 0,
+								typeClassification: 'Primitive',
+							},
+						],
+						decorators: [
+							{
+								type: 'cache',
+								duration: 1,
+							},
+						],
+					},
+				],
+				properties: [],
+				ctor: {
+					kind: 'Constructor',
+					name: 'constructor',
+					parameters: [],
+				},
+				typeClassification: 'Class',
+			});
+		});
+	});
+});

--- a/packages/reflector/tsconfig.json
+++ b/packages/reflector/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src",
+		"outDir": "./build"
+	},
+	"include": ["./src/**/*"]
+}

--- a/packages/reflector/tsconfig.release.json
+++ b/packages/reflector/tsconfig.release.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"include": ["./src/**/*"]
+}


### PR DESCRIPTION
## Changes
This PR contains a brand new version of the Reflector package.
The reflector package is used for the Typescript reflection, it allows the introspection of Typescript classes and functions by returning an object graph containing classes, methods, parameters and also decorator's metadata.

Instead of writing a Reflection library from scratch, we are now relying on the [@plumier/reflect](https://github.com/plumier/plumier/tree/master/packages/reflect), effectively proxying functions and types from the library.