### PR TITLE
Fix: documentation

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -66,7 +66,7 @@ const options = {
 const expressApp: Express = express();
 
 createApp(expressApp, options, app => {
-	app.use(createRouter(CustomerController));
+	app.use(createRouter({ Controller: CustomerController }));	
 });
 
 if (require.main === module) {

--- a/docs/guide/basics/context.md
+++ b/docs/guide/basics/context.md
@@ -28,7 +28,7 @@ function createContext({ req }: { req: Request }): Context {
 }
 
 createApp(expressApp, app => {
-	app.use(createRouter(CustomerController, 'Customer', createContext));
+	app.use(createRouter({ Controller: CustomerController, resourceName: 'Customer', contextFactory: createContext }));
 });
 
 if (require.main === module) {

--- a/docs/guide/basics/swagger-ui.md
+++ b/docs/guide/basics/swagger-ui.md
@@ -36,7 +36,7 @@ const options = {
 const expressApp: Express = express();
 
 createApp(expressApp, options, app => {
-	app.use(createRouter(CustomerController, 'Customer'));
+	app.use(createRouter({ Controller: CustomerController, resourceName: 'Customer' }));
 });
 
 if (require.main === module) {

--- a/examples/rest/src/index.ts
+++ b/examples/rest/src/index.ts
@@ -40,7 +40,12 @@ const expressApp: Express = express();
 const createContext = ({ req }): Context => ({ accountId: req.headers['x-custom-accountid'] });
 
 createApp(expressApp, options, app => {
-	createRouter(CustomerController, 'Customer', createContext, app);
+	createRouter({
+		Controller: CustomerController,
+		resourceName : 'Customer',
+		contextFactory : createContext,
+		router: app
+	});
 });
 
 if (require.main === module) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15981,9 +15981,9 @@
 			"dev": true
 		},
 		"prismjs": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-			"integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
+			"version": "1.27.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+			"integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
 			"dev": true
 		},
 		"private": {

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -382,7 +382,7 @@ function processParameters(params: [CreateRouterParameters] | CreateRouterParame
 
 /**
  * The base class for controls that can be rendered.
- * @param {CreateRouterParameters} options createRouter options
+ * @param {CreateRouterParameters} parameters createRouter options
  *
  * @return the express app router
  */

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -348,7 +348,7 @@ const validateController = (Controller: ClassType) => {
  * @property {string | null} resourceName - The controller name
  * @property {ContextFactory | null} contextFactory - A factory to obtain the request context
  * @property {Router} router - The express router app
- * @prop {AjvFactory | null} [ajvFactory] - A factory to obtain Ajv instance
+ * @property {AjvFactory | null} [ajvFactory] - A factory to obtain Ajv instance
  */
 export type CreateRouterParameters = {
 	Controller: ClassType;

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -343,6 +343,13 @@ const validateController = (Controller: ClassType) => {
 	if (typeof Controller !== 'function') throw new Error('Invalid Controller - not function');
 };
 
+/**
+ * @property {ClassType} Controller - The controller class
+ * @property {string | null} resourceName - The controller name
+ * @property {ContextFactory | null} contextFactory - A factory to obtain the request context
+ * @property {Router} router - The express router app
+ * @prop {AjvFactory | null} [ajvFactory] - A factory to obtain Ajv instance
+ */
 export type CreateRouterParameters = {
 	Controller: ClassType;
 	resourceName?: string | null;
@@ -373,6 +380,12 @@ function processParameters(params: [CreateRouterParameters] | CreateRouterParame
 	};
 }
 
+/**
+ * The base class for controls that can be rendered.
+ * @param {CreateRouterParameters} options createRouter options
+ *
+ * @return the express app router
+ */
 function createRouterAndSwaggerDoc(parameters: CreateRouterParameters): Router | DaVinciExpress;
 /**
  * The base class for controls that can be rendered.

--- a/packages/core/test/support/createAppInstance.ts
+++ b/packages/core/test/support/createAppInstance.ts
@@ -5,7 +5,7 @@
 // const createAppInstance = (options) => {
 // 	const app = express();
 // 	boot(app, { ...options, bootDirPath: './examples/rest/boot' }, app => {
-// 		app.use('/api/customer', createRouter(CustomerController));
+// 		app.use('/api/customer', createRouter({ Controller: CustomerController }));
 // 	});
 
 // 	return app;

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -34,7 +34,7 @@ describe('createRouter', () => {
 		it('should successfully create a router', done => {
 			const model = {};
 			const mockClass = utils.makeMockControllerClass(model, TestController);
-			const router = createRouter(mockClass, 'test');
+			const router = createRouter({ Controller: mockClass, resourceName: 'test' });
 			should(router).have.property('params');
 			should(router.name).be.equal('router');
 			done();
@@ -42,7 +42,7 @@ describe('createRouter', () => {
 
 		it('should fail with missing controller', done => {
 			try {
-				createRouter(null, 'test');
+				createRouter({ Controller: null, resourceName: 'test' });
 			} catch (err) {
 				err.should.have.property('message').equal('Invalid Controller - missing Controller');
 				done();
@@ -117,7 +117,7 @@ describe('createRouter', () => {
 				}
 			}
 
-			const router = createRouter(ParamController);
+			const router = createRouter({ Controller: ParamController });
 
 			should(router)
 				.have.property('stack')
@@ -136,8 +136,13 @@ describe('createRouter', () => {
 				@route.get({ path: '/hello', summary: 'Find' })
 				find() {}
 			}
-			const router = createRouter(TestController, 'test', null, app);
-
+			const router = createRouter({
+				Controller: TestController,
+				resourceName: 'test',
+				contextFactory: null,
+				router: app
+			});
+			
 			should(router).be.equal(app);
 			should(app._router.stack[2].route).match({
 				path: '/api/test/hello',
@@ -183,7 +188,7 @@ describe('createRouter', () => {
 		}
 
 		it('should use the specified success response code', async () => {
-			const router = createRouter(MockController);
+			const router = createRouter({ Controller: MockController });
 
 			const req = {
 				params: {}
@@ -205,7 +210,7 @@ describe('createRouter', () => {
 		});
 
 		it('should use a default response code when none specified', async () => {
-			const router = createRouter(MockController);
+			const router = createRouter({ Controller: MockController });
 
 			const req = {};
 			const res = {

--- a/packages/core/test/unit/route/createRouter.test.ts
+++ b/packages/core/test/unit/route/createRouter.test.ts
@@ -42,9 +42,18 @@ describe('createRouter', () => {
 
 		it('should fail with missing controller', done => {
 			try {
-				createRouter({ Controller: null, resourceName: 'test' });
+				createRouter(null, 'test');
 			} catch (err) {
 				err.should.have.property('message').equal('Invalid Controller - missing Controller');
+				done();
+			}
+		});
+
+		it('should fail with null controller', done => {
+			try {
+				createRouter({ Controller: null, resourceName: 'test' });
+			} catch (err) {
+				err.should.have.property('message').equal('Invalid Controller - not function');
 				done();
 			}
 		});


### PR DESCRIPTION
As pointed out by vlad, we are still using a deprecated createRouter method in examples. Updated to use the latest one.

Added also some documentation to createRouter function and parameters.