### PR TITLE
fix: createMongooseController now produces definitions with prefixed names

### DIFF
--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -437,7 +437,10 @@ function createRouterAndSwaggerDoc(...options): Router | DaVinciExpress {
 	const resourceName = rsName || Controller.name.replace(/Controller$/, '').toLowerCase();
 
 	// get controller metadata
-	const metadata: IControllerDecoratorArgs = Reflector.getMetadata('davinci:openapi:controller', Controller) || {};
+	const metadata: IControllerDecoratorArgs = Reflector.getMetadata('davinci:openapi:controller', Controller).reduce(
+		(acc, controllerMeta) => Object.assign(acc, controllerMeta),
+		{}
+	);
 	const basepath = metadata.basepath || '/';
 	const { resourceSchema } = metadata;
 	const { additionalSchemas } = metadata;

--- a/packages/core/src/route/createRouter.ts
+++ b/packages/core/src/route/createRouter.ts
@@ -437,10 +437,11 @@ function createRouterAndSwaggerDoc(...options): Router | DaVinciExpress {
 	const resourceName = rsName || Controller.name.replace(/Controller$/, '').toLowerCase();
 
 	// get controller metadata
-	const metadata: IControllerDecoratorArgs = Reflector.getMetadata('davinci:openapi:controller', Controller).reduce(
-		(acc, controllerMeta) => Object.assign(acc, controllerMeta),
-		{}
-	);
+	const metadata: IControllerDecoratorArgs =
+		Reflector.getMetadata('davinci:openapi:controller', Controller)?.reduce(
+			(acc, controllerMeta) => Object.assign(acc, controllerMeta),
+			{}
+		) ?? {};
 	const basepath = metadata.basepath || '/';
 	const { resourceSchema } = metadata;
 	const { additionalSchemas } = metadata;

--- a/packages/core/src/route/decorators/route.ts
+++ b/packages/core/src/route/decorators/route.ts
@@ -117,6 +117,6 @@ export interface IControllerDecoratorArgs {
 export function controller(args?: IControllerDecoratorArgs): ClassDecorator {
 	return function(target: Function) {
 		// define new metadata props
-		Reflector.defineMetadata('davinci:openapi:controller', args, target);
+		Reflector.pushMetadata('davinci:openapi:controller', args, target);
 	};
 }

--- a/packages/core/src/route/openapi/createPaths.ts
+++ b/packages/core/src/route/openapi/createPaths.ts
@@ -57,10 +57,11 @@ const createPathsDefinition = (
 	definitions: ISwaggerDefinitions;
 	validationOptions: PathsValidationOptions;
 } => {
-	const controllerMetadata: IControllerDecoratorArgs = Reflector.getMetadata(
-		'davinci:openapi:controller',
-		theClass
-	).reduce((acc, controllerMeta) => Object.assign(acc, controllerMeta), {});
+	const controllerMetadata: IControllerDecoratorArgs =
+		Reflector.getMetadata('davinci:openapi:controller', theClass)?.reduce(
+			(acc, controllerMeta) => Object.assign(acc, controllerMeta),
+			{}
+		) ?? {};
 	const { excludedMethods = [] } = controllerMetadata;
 	const methods: IMethodDecoratorMetadata[] = (
 		Reflector.getMetadata('davinci:openapi:methods', theClass.prototype.constructor) || []

--- a/packages/core/src/route/openapi/createPaths.ts
+++ b/packages/core/src/route/openapi/createPaths.ts
@@ -57,8 +57,10 @@ const createPathsDefinition = (
 	definitions: ISwaggerDefinitions;
 	validationOptions: PathsValidationOptions;
 } => {
-	const controllerMetadata: IControllerDecoratorArgs =
-		Reflector.getMetadata('davinci:openapi:controller', theClass) || {};
+	const controllerMetadata: IControllerDecoratorArgs = Reflector.getMetadata(
+		'davinci:openapi:controller',
+		theClass
+	).reduce((acc, controllerMeta) => Object.assign(acc, controllerMeta), {});
 	const { excludedMethods = [] } = controllerMetadata;
 	const methods: IMethodDecoratorMetadata[] = (
 		Reflector.getMetadata('davinci:openapi:methods', theClass.prototype.constructor) || []

--- a/packages/core/test/unit/route/decorators/route.test.ts
+++ b/packages/core/test/unit/route/decorators/route.test.ts
@@ -280,7 +280,7 @@ describe('route decorators', () => {
 			// @ts-ignore
 			should(Reflector.defineMetadata.getCall(0).args[0]).be.equal('davinci:openapi:controller');
 			// @ts-ignore
-			should(Reflector.defineMetadata.getCall(0).args[1]).be.deepEqual(decoratorArg);
+			should(Reflector.defineMetadata.getCall(0).args[1]).be.deepEqual([decoratorArg]);
 		});
 	});
 });

--- a/packages/mongoose/src/createMongooseController.ts
+++ b/packages/mongoose/src/createMongooseController.ts
@@ -51,7 +51,7 @@ export const createMongooseController = <T extends Constructor<{}>>(
 
 	@openapi.definition({ title: `${Model.modelName}PopulateQueryParameter` })
 	class PopulateQueryParameter {
-		@openapi.prop()
+		@openapi.prop({ required: true })
 		path: string;
 
 		@openapi.prop()
@@ -82,9 +82,7 @@ export const createMongooseController = <T extends Constructor<{}>>(
 		@openapi.prop({
 			type: null,
 			oneOf: [
-				{
-					type: 'object'
-				},
+				{ $ref: `${Model.modelName}PopulateQueryParameter` },
 				{
 					type: 'array',
 					items: { $ref: `${Model.modelName}PopulateQueryParameter` }
@@ -99,9 +97,7 @@ export const createMongooseController = <T extends Constructor<{}>>(
 		@openapi.prop({
 			type: null,
 			oneOf: [
-				{
-					type: 'object'
-				},
+				{ $ref: `${Model.modelName}PopulateQueryParameter` },
 				{
 					type: 'array',
 					items: { $ref: `${Model.modelName}PopulateQueryParameter` }

--- a/packages/mongoose/src/createMongooseController.ts
+++ b/packages/mongoose/src/createMongooseController.ts
@@ -49,7 +49,7 @@ export const createMongooseController = <T extends Constructor<{}>>(
 	// eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
 	const { context, route, httpErrors, openapi, express } = require('@davinci/core');
 
-	@openapi.definition({ title: 'PopulateQueryParameter' })
+	@openapi.definition({ title: `${Model.modelName}PopulateQueryParameter` })
 	class PopulateQueryParameter {
 		@openapi.prop()
 		path: string;
@@ -79,14 +79,36 @@ export const createMongooseController = <T extends Constructor<{}>>(
 		@openapi.prop()
 		$sort?: object;
 
-		@openapi.prop()
-		$populate?: PopulateQueryParameter;
+		@openapi.prop({
+			type: null,
+			oneOf: [
+				{
+					type: 'object'
+				},
+				{
+					type: 'array',
+					items: { $ref: `${Model.modelName}PopulateQueryParameter` }
+				}
+			]
+		})
+		$populate?: PopulateQueryParameter | PopulateQueryParameter[];
 	}
 
-	@openapi.definition({ title: 'QueryParameters' })
+	@openapi.definition({ title: `${Model.modelName}QueryParameters` })
 	class QueryParameters {
-		@openapi.prop({ type: PopulateQueryParameter })
-		$populate?: PopulateQueryParameter;
+		@openapi.prop({
+			type: null,
+			oneOf: [
+				{
+					type: 'object'
+				},
+				{
+					type: 'array',
+					items: { $ref: `${Model.modelName}PopulateQueryParameter` }
+				}
+			]
+		})
+		$populate?: PopulateQueryParameter | PopulateQueryParameter[];
 
 		@openapi.prop()
 		$limit?: number;
@@ -144,6 +166,7 @@ export const createMongooseController = <T extends Constructor<{}>>(
 
 		return next(err);
 	})
+	@route.controller({ additionalSchemas: [PopulateQueryParameter] })
 	class MongooseController implements IMongooseController {
 		maxLimit: number;
 


### PR DESCRIPTION
## Changes included

#### createMongooseController now produces definitions with prefixed names
It's meant to avoid registering multiple definitions with the same name.
This is particularly important after the AJV cache mechanism introduced recently

#### QueryParameters['$populate'] type has been changed to oneOf: [object, objects[]]
The type for the QueryParameters['$populate'] has been modified to allow passing an array of population objects