### PR TITLE
[next] feat(lifecycle): added onRegister lifecycle hook for modules

### DIFF
--- a/packages/core/src/Module.ts
+++ b/packages/core/src/Module.ts
@@ -5,13 +5,23 @@
 
 import type { App } from './App';
 
-export type ModuleStatus = 'unloaded' | 'initializing' | 'initialized' | 'destroying' | 'destroyed' | 'error';
+export type ModuleStatus =
+	| 'unloaded'
+	| 'registering'
+	| 'registered'
+	| 'initializing'
+	| 'initialized'
+	| 'destroying'
+	| 'destroyed'
+	| 'error';
 
 export abstract class Module {
 	/**
 	 * @returns {string | string[]} the identifier (or identifiers) of the module
 	 */
 	abstract getModuleId(): string | string[];
+
+	onRegister?(app: App): unknown | Promise<unknown>;
 
 	onInit?(app: App): unknown | Promise<unknown>;
 

--- a/packages/core/test/unit/App.test.ts
+++ b/packages/core/test/unit/App.test.ts
@@ -34,9 +34,25 @@ describe('App', () => {
 				throw new Error('Error within MyModule');
 			}
 		}
-		const app = createApp().registerModule([new MyModule()]);
+		const app = createApp();
+		await app.registerModule([new MyModule()]);
 
 		await expect(app.init()).to.be.rejectedWith('Error within MyModule');
+	});
+
+	it('should throw and exception and exit if an error happens during a module registration', async () => {
+		class MyModule implements Module {
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onRegister() {
+				throw new Error('Error within MyModule');
+			}
+		}
+		const app = createApp();
+
+		await expect(app.registerModule([new MyModule()])).to.be.rejectedWith('Error within MyModule');
 	});
 
 	it('should ignore exceptions on modules happening on destroy', async () => {
@@ -49,7 +65,8 @@ describe('App', () => {
 				throw new Error('Error within MyModule');
 			}
 		}
-		const app = createApp().registerModule([new MyModule()]);
+		const app = createApp();
+		await app.registerModule([new MyModule()]);
 		const moduleLoggerErrorSpy = sinon.spy(app.logger, 'error');
 		const appLoggerFatalSpy = sinon.spy(app.logger, 'fatal');
 		await app.init();
@@ -163,7 +180,7 @@ describe('App', () => {
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 
 		expect(app.getModules()[0]).to.be.equal(myModule);
 	});
@@ -185,7 +202,7 @@ describe('App', () => {
 
 		const myModule1 = new MyModule1();
 		const myModule2 = new MyModule2();
-		app.registerModule([myModule1, myModule2]);
+		await app.registerModule([myModule1, myModule2]);
 
 		expect(app.getModules()).to.be.deep.equal([myModule1, myModule2]);
 	});
@@ -205,7 +222,7 @@ describe('App', () => {
 		const myModule2 = new MyModule2();
 
 		try {
-			app.registerModule([myModule1, myModule2]);
+			await app.registerModule([myModule1, myModule2]);
 			throw new Error('failed test');
 		} catch (err) {
 			expect(err.message).to.match(/A module with the same identifier (.+) has already been registered/);
@@ -225,7 +242,7 @@ describe('App', () => {
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 		await app.init();
 
 		expect(myModule.app).to.be.equal(app);
@@ -244,9 +261,28 @@ describe('App', () => {
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 		await app.init();
 		await app.shutdown();
+
+		expect(myModule.app).to.be.equal(app);
+	});
+
+	it("should execute the modules' onRegister hook", async () => {
+		const app = createApp();
+		class MyModule implements Module {
+			app: App;
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onRegister(app: App) {
+				this.app = app;
+			}
+		}
+		const myModule = new MyModule();
+		await app.registerModule(myModule);
+		await app.init();
 
 		expect(myModule.app).to.be.equal(app);
 	});
@@ -278,7 +314,9 @@ describe('App', () => {
 			}
 		}
 
-		const app = new App().registerModule(new MyModule());
+		const app = new App();
+		await app.registerModule(new MyModule());
+
 		await expect(app.init()).to.be.rejected;
 		expect(app.getStatus()).to.be.equal('error');
 	});
@@ -291,7 +329,8 @@ describe('App', () => {
 			}
 		}
 
-		const app = new App().registerModule(new MyModule());
+		const app = new App();
+		await app.registerModule(new MyModule());
 		const module = await app.getModuleById('myModule');
 
 		expect(module).to.be.instanceof(MyModule);
@@ -310,7 +349,8 @@ describe('App', () => {
 			}
 		}
 
-		const app = new App().registerModule(new MyModule());
+		const app = new App();
+		await app.registerModule(new MyModule());
 		app.init();
 		const module = await app.getModuleById<MyModule>('myModule', true);
 

--- a/packages/core/test/unit/App.test.ts
+++ b/packages/core/test/unit/App.test.ts
@@ -40,6 +40,29 @@ describe('App', () => {
 		await expect(app.init()).to.be.rejectedWith('Error within MyModule');
 	});
 
+	it('should wait for the modules registration to be complete, before initializing', async () => {
+		const completionOrder = [];
+		class MyModule implements Module {
+			getModuleId() {
+				return 'myModule';
+			}
+
+			async onRegister() {
+				await new Promise(resolve => setTimeout(() => resolve(null), 200));
+				completionOrder.push('onRegister');
+			}
+
+			async onInit() {
+				completionOrder.push('onInit');
+			}
+		}
+		const app = createApp();
+		app.registerModule([new MyModule()]);
+		await app.init();
+
+		expect(completionOrder).to.be.deep.equal(['onRegister', 'onInit']);
+	});
+
 	it('should throw and exception and exit if an error happens during a module registration', async () => {
 		class MyModule implements Module {
 			getModuleId() {

--- a/packages/health-checks/test/unit/HealthChecksModule.test.ts
+++ b/packages/health-checks/test/unit/HealthChecksModule.test.ts
@@ -30,7 +30,8 @@ describe('HealthChecksModule', () => {
 					{ name: 'readiness', endpoint: '/checks/readiness' }
 				]
 			});
-			app.registerModule(fastifyHttpServer).registerModule(healthChecksModule);
+			await app.registerModule(fastifyHttpServer);
+			await app.registerModule(healthChecksModule);
 			const onInitSpy = sinon.spy(healthChecksModule, 'onInit');
 
 			await app.init();

--- a/packages/http-server-express/src/ExpressHttpServer.ts
+++ b/packages/http-server-express/src/ExpressHttpServer.ts
@@ -30,13 +30,16 @@ export class ExpressHttpServer extends HttpServerModule<Request, Response, Serve
 		this.instance = app ?? express();
 	}
 
-	async onInit(app) {
+	async onRegister(app) {
 		this.app = app;
 		this.logger.level = this.app.getOptions()?.logger?.level;
 		this.registerMiddlewares();
 		await super.createRoutes();
 		// this.registerErrorHandlers();
 		this.initHttpServer();
+	}
+
+	async onInit() {
 		return this.listen();
 	}
 

--- a/packages/http-server-fastify/src/FastifyHttpServer.ts
+++ b/packages/http-server-fastify/src/FastifyHttpServer.ts
@@ -46,7 +46,7 @@ export class FastifyHttpServer extends HttpServerModule<
 		super(moduleOptions);
 	}
 
-	async onInit(app) {
+	async onRegister(app: App) {
 		this.app = app;
 		this.logger.level = this.app.getOptions()?.logger?.level;
 		this.initHttpServer();
@@ -54,6 +54,9 @@ export class FastifyHttpServer extends HttpServerModule<
 		await this.registerPlugins();
 
 		await super.createRoutes();
+	}
+
+	async onInit() {
 		return this.listen();
 	}
 

--- a/packages/http-server/test/unit/HttpServerModule.test.ts
+++ b/packages/http-server/test/unit/HttpServerModule.test.ts
@@ -137,7 +137,9 @@ describe('HttpServerModule', () => {
 				}
 			}
 			const dummyHttpServer = new MyDummyHttpServer();
-			await new App().registerController(CustomerController).registerModule(dummyHttpServer).init();
+			const app = new App();
+			await app.registerController(CustomerController).registerModule(dummyHttpServer);
+			await app.init();
 			const [[getRoute, postRoute]] = await dummyHttpServer.createRoutes();
 
 			expect(getRoute[0]).to.be.equal('get');


### PR DESCRIPTION
## Changes

A new App lifecycle stage has been added, that allows modules to perform actions after registering them.
The new lifecycle schema for the App is:
`'unloaded' ->'registering' ->'registered' ->'initializing' ->'initialized' ->'destroying' ->'destroyed'`
Additionally, a new `onRegister` hook has been made available for modules.


## Motivation
That differentiation between the registration and initialization phase is particularly important for the Fastify and Express modules:
The routes registration happens in the App registration phase, while the actual HTTP server start will happen in the initialization phase.

This allows other modules (OpenAPI or HealthCheck for example) to register routes on the HttpModule, before starting the server.