### PR TITLE
refactor: onRegister phase + modules internal status field

### DIFF
--- a/examples/next-api-express/src/index.ts
+++ b/examples/next-api-express/src/index.ts
@@ -1,3 +1,8 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createApp } from '@davinci/core';
 import { ExpressHttpServer } from '@davinci/http-server-express';
 import { CustomerController } from './api/customer';
@@ -5,8 +10,7 @@ import { CustomerController } from './api/customer';
 const app = createApp();
 const contextFactory = ({ request }) => ({ accountId: request.headers['x-accountid'] });
 
-app.registerController([CustomerController])
-	.registerModule(new ExpressHttpServer().setContextFactory(contextFactory))
-	.init();
+app.registerController([CustomerController]).registerModule(new ExpressHttpServer().setContextFactory(contextFactory));
+app.init();
 
 export default app;

--- a/examples/next-api-fastify/src/index.ts
+++ b/examples/next-api-fastify/src/index.ts
@@ -10,8 +10,7 @@ import { CustomerController } from './api/customer';
 const app = createApp();
 const contextFactory = ({ request }) => ({ accountId: request.headers['x-accountid'] });
 
-app.registerController([CustomerController])
-	.registerModule(new FastifyHttpServer().setContextFactory(contextFactory))
-	.init();
+app.registerController([CustomerController]).registerModule(new FastifyHttpServer().setContextFactory(contextFactory));
+app.init();
 
 export default app;

--- a/packages/core/src/App.ts
+++ b/packages/core/src/App.ts
@@ -209,7 +209,7 @@ export class App extends Module {
 	}
 
 	public async getModuleById<M extends Module = Module>(moduleId: string, waitForStatus?: ModuleStatus): Promise<M> {
-		const statusOrders = [
+		const WEIGHTED_STATUSES = [
 			'unloaded',
 			'registering',
 			'registered',
@@ -221,7 +221,7 @@ export class App extends Module {
 		];
 		const module = this.modulesDic[moduleId];
 		if (waitForStatus) {
-			if (statusOrders.indexOf(module.getStatus()) >= statusOrders.indexOf(waitForStatus)) {
+			if (WEIGHTED_STATUSES.indexOf(module.getStatus()) >= WEIGHTED_STATUSES.indexOf(waitForStatus)) {
 				return module as M;
 			}
 

--- a/packages/core/src/Module.ts
+++ b/packages/core/src/Module.ts
@@ -3,15 +3,43 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { EventEmitter } from 'events';
 import type { App } from './App';
 
+export type ModuleStatus =
+	| 'unloaded'
+	| 'registering'
+	| 'registered'
+	| 'initializing'
+	| 'initialized'
+	| 'destroying'
+	| 'destroyed'
+	| 'error';
+
+const statusSym = Symbol('status');
+
 export abstract class Module {
+	[statusSym]: ModuleStatus = 'unloaded';
+	eventBus = new EventEmitter();
+
 	/**
 	 * @returns {string | string[]} the identifier (or identifiers) of the module
 	 */
 	abstract getModuleId(): string | string[];
 
-	onInit?(app: App): void | Promise<void>;
+	onRegister?(app: App): unknown | Promise<unknown>;
 
-	onDestroy?(app: App): void | Promise<void>;
+	onInit?(app: App): unknown | Promise<unknown>;
+
+	onDestroy?(app: App): unknown | Promise<unknown>;
+
+	public setStatus(newStatus: ModuleStatus) {
+		this[statusSym] = newStatus;
+		const eventName = newStatus === 'error' ? 'module-error' : newStatus;
+		this.eventBus.emit(eventName);
+	}
+
+	public getStatus() {
+		return this[statusSym];
+	}
 }

--- a/packages/core/test/unit/App.test.ts
+++ b/packages/core/test/unit/App.test.ts
@@ -3,22 +3,29 @@
  * SPDX-License-Identifier: MIT
  */
 
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import { decorate, decorateParameter, reflect } from '@davinci/reflector';
 import { App, createApp, Module } from '../../src';
 import { expect } from '../support/chai';
 
+const sinon = createSandbox();
+
 describe('App', () => {
-	it('should initialize correctly', () => {
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it('should instantiate correctly', () => {
 		class MyController {}
-		const app = createApp({ controllers: [MyController] });
+		const app = new App({ controllers: [MyController] });
 
 		expect(app.getModules()).to.be.an('array');
 		expect(app.getControllers()).to.be.deep.equal([MyController]);
+		expect(app.getModuleId()).to.be.equal('app');
 	});
 
 	it('should throw and exception and exit if an error happens during init', async () => {
-		class MyModule implements Module {
+		class MyModule extends Module {
 			getModuleId() {
 				return 'myModule';
 			}
@@ -27,9 +34,83 @@ describe('App', () => {
 				throw new Error('Error within MyModule');
 			}
 		}
-		const app = createApp().registerModule([new MyModule()]);
+		const app = createApp();
+		await app.registerModule([new MyModule()]);
 
 		await expect(app.init()).to.be.rejectedWith('Error within MyModule');
+	});
+
+	it('should wait for the modules registration to be complete, before initializing', async () => {
+		const completionOrder = [];
+		class MyModule extends Module {
+			getModuleId() {
+				return 'myModule';
+			}
+
+			async onRegister() {
+				await new Promise(resolve => setTimeout(() => resolve(null), 200));
+				completionOrder.push('onRegister');
+			}
+
+			async onInit() {
+				completionOrder.push('onInit');
+			}
+		}
+		const app = createApp();
+		app.registerModule([new MyModule()]);
+		await app.init();
+
+		expect(completionOrder).to.be.deep.equal(['onRegister', 'onInit']);
+	});
+
+	it('should throw and exception and exit if an error happens during a module registration', async () => {
+		class MyModule extends Module {
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onRegister() {
+				throw new Error('Error within MyModule');
+			}
+		}
+		const app = createApp();
+
+		await expect(app.registerModule([new MyModule()])).to.be.rejectedWith('Error within MyModule');
+	});
+
+	it('should ignore exceptions on modules happening on destroy', async () => {
+		class MyModule extends Module {
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onDestroy() {
+				throw new Error('Error within MyModule');
+			}
+		}
+		const app = createApp();
+		await app.registerModule([new MyModule()]);
+		const moduleLoggerErrorSpy = sinon.spy(app.logger, 'error');
+		const appLoggerFatalSpy = sinon.spy(app.logger, 'fatal');
+		await app.init();
+
+		await expect(app.shutdown()).to.not.be.rejected;
+		expect(moduleLoggerErrorSpy.getCall(0).lastArg).to.be.equal('Error while destroying module');
+		expect(appLoggerFatalSpy.called).to.be.false;
+	});
+
+	it('should throw and exception and exit if an error happens in onDestroy', async () => {
+		class MyApp extends App {
+			onDestroy() {
+				throw new Error('bad error');
+			}
+		}
+		const app = new MyApp();
+		const appLoggerFatalSpy = sinon.spy(app.logger, 'fatal');
+		await app.init();
+
+		await expect(app.shutdown()).to.be.rejectedWith('bad error');
+		expect(appLoggerFatalSpy.getCall(0).lastArg).to.be.equal('Fatal error');
 	});
 
 	it('should register controllers', () => {
@@ -115,21 +196,21 @@ describe('App', () => {
 
 	it('should be able to register a module', async () => {
 		const app = createApp();
-		class MyModule implements Module {
+		class MyModule extends Module {
 			app: App;
 			getModuleId() {
 				return 'myModule';
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 
 		expect(app.getModules()[0]).to.be.equal(myModule);
 	});
 
 	it('should be able to register multiple modules #1', async () => {
 		const app = createApp();
-		class MyModule1 implements Module {
+		class MyModule1 extends Module {
 			app: App;
 			getModuleId() {
 				return 'myModule1';
@@ -144,14 +225,14 @@ describe('App', () => {
 
 		const myModule1 = new MyModule1();
 		const myModule2 = new MyModule2();
-		app.registerModule([myModule1, myModule2]);
+		await app.registerModule([myModule1, myModule2]);
 
 		expect(app.getModules()).to.be.deep.equal([myModule1, myModule2]);
 	});
 
 	it('should error trying to register multiple modules with same identifier', async () => {
 		const app = createApp();
-		class MyModule1 implements Module {
+		class MyModule1 extends Module {
 			app: App;
 			getModuleId() {
 				return ['myModule'];
@@ -164,7 +245,7 @@ describe('App', () => {
 		const myModule2 = new MyModule2();
 
 		try {
-			app.registerModule([myModule1, myModule2]);
+			await app.registerModule([myModule1, myModule2]);
 			throw new Error('failed test');
 		} catch (err) {
 			expect(err.message).to.match(/A module with the same identifier (.+) has already been registered/);
@@ -173,7 +254,7 @@ describe('App', () => {
 
 	it("should execute the modules' onInit hook", async () => {
 		const app = createApp();
-		class MyModule implements Module {
+		class MyModule extends Module {
 			app: App;
 			getModuleId() {
 				return 'myModule';
@@ -184,7 +265,7 @@ describe('App', () => {
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 		await app.init();
 
 		expect(myModule.app).to.be.equal(app);
@@ -192,7 +273,7 @@ describe('App', () => {
 
 	it("should execute the the modules' onDestroy hook", async () => {
 		const app = createApp();
-		class MyModule implements Module {
+		class MyModule extends Module {
 			app: App;
 			getModuleId() {
 				return 'myModule';
@@ -203,10 +284,181 @@ describe('App', () => {
 			}
 		}
 		const myModule = new MyModule();
-		app.registerModule(myModule);
+		await app.registerModule(myModule);
 		await app.init();
 		await app.shutdown();
 
 		expect(myModule.app).to.be.equal(app);
+	});
+
+	it("should execute the modules' onRegister hook", async () => {
+		const app = createApp();
+		class MyModule extends Module {
+			app: App;
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onRegister(app: App) {
+				this.app = app;
+			}
+		}
+		const myModule = new MyModule();
+		await app.registerModule(myModule);
+		await app.init();
+
+		expect(myModule.app).to.be.equal(app);
+	});
+
+	it('should track lifecycle changes via the status property #1', async () => {
+		const app = new App();
+		expect(app.getStatus()).to.be.equal('unloaded');
+
+		const initPromise = app.init();
+		expect(app.getStatus()).to.be.equal('initializing');
+		await initPromise;
+		expect(app.getStatus()).to.be.equal('initialized');
+
+		const shutdownPromise = app.shutdown();
+		expect(app.getStatus()).to.be.equal('destroying');
+		await shutdownPromise;
+		expect(app.getStatus()).to.be.equal('destroyed');
+	});
+
+	it('should track lifecycle changes via the status property #2', async () => {
+		class MyModule extends Module {
+			app: App;
+			getModuleId() {
+				return 'myModule';
+			}
+
+			onInit() {
+				throw new Error('error');
+			}
+		}
+
+		const app = new App();
+		await app.registerModule(new MyModule());
+
+		await expect(app.init()).to.be.rejected;
+		expect(app.getStatus()).to.be.equal('error');
+	});
+
+	it('should get a module by its id', async () => {
+		class MyModule extends Module {
+			app: App;
+			getModuleId() {
+				return 'myModule';
+			}
+		}
+
+		const app = new App();
+		await app.registerModule(new MyModule());
+		const module = await app.getModuleById('myModule');
+
+		expect(module).to.be.instanceof(MyModule);
+	});
+
+	it('should get an initialized module by its id', async () => {
+		class MyModule extends Module {
+			app: App;
+			initialized: boolean;
+			onInit() {
+				this.initialized = true;
+			}
+
+			getModuleId() {
+				return 'myModule';
+			}
+		}
+
+		const app = new App();
+		await app.registerModule(new MyModule());
+		app.init();
+		const module = await app.getModuleById<MyModule>('myModule', 'initialized');
+
+		expect(module.initialized).to.be.true;
+	});
+
+	it('should get a module by its id and status', async () => {
+		let initialized;
+		class MyModule1 extends Module {
+			getModuleId() {
+				return 'myModule1';
+			}
+
+			onInit() {
+				return new Promise(resolve => setTimeout(() => resolve(null), 100));
+			}
+		}
+
+		class MyModule2 extends Module {
+			getModuleId() {
+				return 'myModule2';
+			}
+
+			async onInit(app) {
+				const module1 = await app.getModuleById('myModule1', 'initialized');
+				expect(module1).to.be.instanceof(MyModule1);
+				expect(module1.getStatus()).to.be.equal('initialized');
+				initialized = true;
+			}
+		}
+
+		const app = new App();
+		await app.registerModule(new MyModule1(), new MyModule2());
+		await app.init();
+
+		expect(initialized).to.be.true;
+	});
+
+	it('should get a module by its id and a more advanced status in the lifecycle chain', async () => {
+		class MyModule extends Module {
+			getModuleId() {
+				return 'myModule1';
+			}
+		}
+
+		const app = new App();
+		await app.registerModule(new MyModule());
+		await app.init();
+
+		const module1 = await app.getModuleById('myModule1', 'registering');
+		expect(module1).to.be.instanceof(MyModule);
+		expect(module1.getStatus()).to.be.equal('initialized');
+	});
+
+	it('should ignore duplicated shutdown signals', async () => {
+		const app = new App({ shutdown: { enabled: true, signals: ['SIGTERM'] } });
+		const shutdownSpy = sinon.spy(app, 'shutdown');
+		sinon.stub(process, 'exit');
+		await app.init();
+
+		// @ts-ignore
+		process.emit('SIGTERM');
+		// @ts-ignore
+		process.emit('SIGTERM');
+
+		expect(shutdownSpy.callCount).to.be.equal(1);
+	});
+
+	it('should exit 1 in case of errors during shutdown', async () => {
+		const app = new App({ shutdown: { enabled: true, signals: ['SIGTERM'] } });
+		sinon.stub(app, 'shutdown').throws('bad error');
+		const processExitStub = sinon.stub(process, 'exit');
+		await app.init();
+
+		// @ts-ignore
+		process.emit('SIGTERM');
+
+		expect(processExitStub.firstCall.lastArg).to.be.equal(1);
+	});
+
+	it('should return the options', () => {
+		class MyController {}
+		const options = { controllers: [MyController], shutdown: { enabled: true } };
+		const app = new App(options);
+
+		expect(app.getOptions()).to.containSubset(options);
 	});
 });

--- a/packages/core/test/unit/Module.test.ts
+++ b/packages/core/test/unit/Module.test.ts
@@ -1,0 +1,22 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Module } from '../../src';
+import { expect } from '../support/chai';
+
+describe('Module', () => {
+	it('should be able to get and set status', () => {
+		class MyModule extends Module {
+			getModuleId(): string | string[] {
+				return 'myModule';
+			}
+		}
+
+		const module = new MyModule();
+		module.setStatus('registering');
+
+		expect(module.getStatus()).to.be.equal('registering');
+	});
+});

--- a/packages/http-server/test/unit/HttpServerModule.test.ts
+++ b/packages/http-server/test/unit/HttpServerModule.test.ts
@@ -128,6 +128,10 @@ describe('HttpServerModule', () => {
 				create() {}
 			}
 			class MyDummyHttpServer extends DummyHttpServer {
+				onRegister(app: App) {
+					this.app = app;
+				}
+
 				get(...args) {
 					return ['get', ...args];
 				}
@@ -137,7 +141,8 @@ describe('HttpServerModule', () => {
 				}
 			}
 			const dummyHttpServer = new MyDummyHttpServer();
-			await new App().registerController(CustomerController).registerModule(dummyHttpServer).init();
+			await new App().registerController(CustomerController).registerModule(dummyHttpServer);
+			await app.init();
 			const [[getRoute, postRoute]] = await dummyHttpServer.createRoutes();
 
 			expect(getRoute[0]).to.be.equal('get');


### PR DESCRIPTION
## Changes
- core: added a new `onRegister` lifecycle hook
- core: Now modules have an internal status field
- core: added ability to respond to shutdown signals