### PR TITLE
fix(mongoose): renamed to davinciContext, changed generateSchema behaviour

### DIFF
--- a/packages/mongoose/src/generateModel.ts
+++ b/packages/mongoose/src/generateModel.ts
@@ -21,7 +21,8 @@ export const generateSchema = <T>(
 		// eslint-disable-next-line no-shadow
 		schemaType: ClassType,
 		// eslint-disable-next-line no-shadow
-		options: SchemaOptions = { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } }
+		options: SchemaOptions = { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } },
+		forceCreateSchema?: boolean
 	) => {
 		const classReflection = reflect(schemaType);
 		const propsWithMeta: {
@@ -105,7 +106,7 @@ export const generateSchema = <T>(
 		// get schema options
 		const schemaDecoration = classReflection.decorators.find(d => d[DecoratorId] === 'mongoose.schema');
 		const schemaOptions = schemaDecoration?.options;
-		const schema = schemaDecoration && new Schema(definition, options ?? schemaOptions);
+		const schema = (forceCreateSchema || schemaDecoration) && new Schema(definition, options ?? schemaOptions);
 
 		// register methods
 		const methods = classReflection.methods.reduce((acc, methodReflection) => {
@@ -175,7 +176,7 @@ export const generateSchema = <T>(
 		return { schema: schema ?? definition, ...(!schema ? { indexes, populatedVirtuals, virtuals, methods } : {}) };
 	};
 
-	const { schema } = recursivelyGenerateSchema(schemaType, options);
+	const { schema } = recursivelyGenerateSchema(schemaType, options, true);
 
 	return schema;
 };

--- a/packages/mongoose/src/hooks.ts
+++ b/packages/mongoose/src/hooks.ts
@@ -1,9 +1,9 @@
 /*
- * © Copyright 2020 HP Development Company, L.P.
+ * © Copyright 2022 HP Development Company, L.P.
  * SPDX-License-Identifier: MIT
  */
 
-import { Document, Schema, Query } from 'mongoose';
+import { Document, Query, Schema } from 'mongoose';
 
 type Stage = 'pre' | 'post';
 
@@ -39,31 +39,31 @@ type Hook =
 export interface PreArgs<Context = unknown, ModelSchema = unknown> {
 	query: Query<ModelSchema, ModelSchema & Document>;
 	hookName: Hook;
-	davinciCtx: Context;
+	davinciContext: Context;
 }
 export interface AfterArgs<Context = unknown, ModelSchema = unknown> {
 	query: Query<ModelSchema, ModelSchema & Document>;
 	hookName: Hook;
-	davinciCtx: Context;
+	davinciContext: Context;
 	result: (ModelSchema & Document) | (ModelSchema & Document)[];
 }
 
 export interface AfterRawResultArgs<Context = unknown, ModelSchema = unknown> {
 	query: Query<ModelSchema, ModelSchema & Document>;
 	hookName: Hook;
-	davinciCtx: Context;
+	davinciContext: Context;
 	rawResult: unknown;
 }
 
 export interface DocumentPreArgs<Context = unknown, ModelSchema = unknown> {
 	hookName: Hook;
-	davinciCtx: Context;
+	davinciContext: Context;
 	doc: Document & ModelSchema;
 }
 export interface DocumentPostArgs<Context = unknown, ModelSchema = unknown> {
 	result: Document;
 	hookName: Hook;
-	davinciCtx: Context;
+	davinciContext: Context;
 	doc: Document & ModelSchema;
 }
 
@@ -78,7 +78,7 @@ export interface DocumentPostArgs<Context = unknown, ModelSchema = unknown> {
  * @param thisObj
  * @param result
  * @param rest
- * @param davinciCtx
+ * @param davinciContext
  */
 const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 	stage: Stage,
@@ -90,7 +90,7 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 		thisObj,
 		result,
 		rest,
-		davinciCtx
+		davinciContext
 	}: {
 		isReadHook: boolean;
 		isWriteHook: boolean;
@@ -98,7 +98,7 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 		thisObj: Document | Query<ResultType, ResultType & Document>;
 		result?: any;
 		rest?: unknown[];
-		davinciCtx?: Context;
+		davinciContext?: Context;
 	}
 ):
 	| PreArgs<ResultType>
@@ -112,14 +112,14 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 	const createPreArgs = (): PreArgs<Context, ResultType> => ({
 		query: thisObj as Query<ResultType, ResultType & Document>,
 		hookName,
-		davinciCtx
+		davinciContext
 	});
 
 	// createAfterArgs creates the arguments for `after(Read|Write|Delete)` hooks
 	const createAfterArgs = (): AfterArgs<Context, ResultType> => ({
 		query: thisObj as Query<ResultType, ResultType & Document>,
 		hookName,
-		davinciCtx,
+		davinciContext,
 		result
 	});
 
@@ -127,20 +127,20 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 	const createAfterRawResultArgs = (): AfterRawResultArgs<Context, ResultType> => ({
 		query: thisObj as Query<ResultType, ResultType & Document>,
 		hookName,
-		davinciCtx,
+		davinciContext,
 		rawResult: result
 	});
 
 	// createDocumentPreArgs creates the arguments for `before(Read|Write|Delete)` hooks triggered by
 	// document middlewares: https://mongoosejs.com/docs/middleware.html
-	const createDocumentPreArgs = (): DocumentPreArgs => ({ hookName, davinciCtx, doc: thisObj as Document });
+	const createDocumentPreArgs = (): DocumentPreArgs => ({ hookName, davinciContext, doc: thisObj as Document });
 
 	// createDocumentPostArgs creates the arguments for `after(Read|Write|Delete)` hooks triggered by
 	// document middlewares: https://mongoosejs.com/docs/middleware.html
 	const createDocumentPostArgs = (): DocumentPostArgs => ({
 		result: thisObj as Document,
 		hookName,
-		davinciCtx,
+		davinciContext,
 		doc: rest[1] as Document
 	});
 
@@ -150,7 +150,7 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
 				read: createPreArgs
 			},
 			post: {
-				read: () => ({ query: thisObj, hookName, davinciCtx, count: result })
+				read: () => ({ query: thisObj, hookName, davinciContext, count: result })
 			}
 		},
 		find: {
@@ -264,50 +264,52 @@ const createHandlerArgs = <Context = unknown, ResultType = unknown>(
  * @param hooksList
  * @param stage
  */
-const createRegisterHooks = (hooksList, stage: Stage) => <T>(mongooseSchema: T, handler): void => {
-	const isReadHook = hooksList === READ_HOOKS;
-	const isWriteHook = hooksList === WRITE_HOOKS;
-	const isDeleteHook = hooksList === DELETE_HOOKS;
+const createRegisterHooks =
+	(hooksList, stage: Stage) =>
+	<T>(mongooseSchema: T, handler): void => {
+		const isReadHook = hooksList === READ_HOOKS;
+		const isWriteHook = hooksList === WRITE_HOOKS;
+		const isDeleteHook = hooksList === DELETE_HOOKS;
 
-	const hasContextInOptions = (hook: Hook): boolean =>
-		isReadHook || isDeleteHook || ['findOneAndUpdate', 'update', 'updateMany', 'updateOne'].includes(hook);
-	const hasContextInSaveOptions = (hook: Hook): boolean =>
-		isWriteHook && !['findOneAndUpdate', 'update', 'updateMany', 'updateOne'].includes(hook);
+		const hasContextInOptions = (hook: Hook): boolean =>
+			isReadHook || isDeleteHook || ['findOneAndUpdate', 'update', 'updateMany', 'updateOne'].includes(hook);
+		const hasContextInSaveOptions = (hook: Hook): boolean =>
+			isWriteHook && !['findOneAndUpdate', 'update', 'updateMany', 'updateOne'].includes(hook);
 
-	hooksList.forEach(hook =>
-		mongooseSchema[stage](hook, async function hookHandlerWrapper(result, ...rest) {
-			let davinciCtx;
-			if (hasContextInOptions(hook)) {
-				davinciCtx = this.options?.davinciCtx;
-				if (this.options?.skipHooks) {
-					return;
+		hooksList.forEach(hook =>
+			mongooseSchema[stage](hook, async function hookHandlerWrapper(result, ...rest) {
+				let davinciContext;
+				if (hasContextInOptions(hook)) {
+					davinciContext = this.options?.davinciContext;
+					if (this.options?.skipHooks) {
+						return;
+					}
 				}
-			}
-			if (hasContextInSaveOptions(hook)) {
-				// eslint-disable-next-line no-underscore-dangle
-				davinciCtx = this.$__.saveOptions?.davinciCtx;
-				// eslint-disable-next-line no-underscore-dangle
-				if (this.$__.saveOptions?.skipHooks) {
-					return;
+				if (hasContextInSaveOptions(hook)) {
+					// eslint-disable-next-line no-underscore-dangle
+					davinciContext = this.$__.saveOptions?.davinciContext;
+					// eslint-disable-next-line no-underscore-dangle
+					if (this.$__.saveOptions?.skipHooks) {
+						return;
+					}
 				}
-			}
 
-			const args = createHandlerArgs<T, T & Document>(stage, hook, {
-				isReadHook,
-				isWriteHook,
-				isDeleteHook,
-				thisObj: this,
-				result,
-				davinciCtx,
-				rest
-			});
+				const args = createHandlerArgs<T, T & Document>(stage, hook, {
+					isReadHook,
+					isWriteHook,
+					isDeleteHook,
+					thisObj: this,
+					result,
+					davinciContext,
+					rest
+				});
 
-			if (args) {
-				await handler(args);
-			}
-		})
-	);
-};
+				if (args) {
+					await handler(args);
+				}
+			})
+		);
+	};
 
 export type Handler<Context = unknown, ModelSchema = unknown> = {
 	beforeRead: (args: PreArgs<Context, ModelSchema>) => unknown | Promise<unknown>;

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -14,3 +14,9 @@ export const mgoose = {
 	...hooks,
 	...decorators
 };
+
+declare module 'mongoose' {
+	interface QueryOptions {
+		davinciContext?: unknown;
+	}
+}

--- a/packages/mongoose/test/unit/generateModel.test.ts
+++ b/packages/mongoose/test/unit/generateModel.test.ts
@@ -4,7 +4,7 @@
  */
 
 import Sinon from 'sinon';
-import { Model, SchemaTypes } from 'mongoose';
+import { Model, Schema, SchemaTypes } from 'mongoose';
 import { expect } from '../support/chai';
 import { mgoose } from '../../src';
 
@@ -28,7 +28,7 @@ describe('typed mongoose', () => {
 
 			const schema = mgoose.generateSchema(Customer, {});
 
-			expect(schema).to.be.deep.equal({
+			expect(schema.obj).to.be.deep.equal({
 				firstname: {
 					type: String
 				},
@@ -54,7 +54,7 @@ describe('typed mongoose', () => {
 
 			const schema = mgoose.generateSchema(Customer, {});
 
-			expect(schema).be.deep.equal({
+			expect(schema.obj).to.be.deep.equal({
 				birth: {
 					type: {
 						place: {
@@ -81,7 +81,7 @@ describe('typed mongoose', () => {
 
 			const schema = mgoose.generateSchema(Customer, {});
 
-			expect(schema).be.deep.equal({
+			expect(schema.obj).to.be.deep.equal({
 				birth: [
 					{
 						type: {
@@ -117,9 +117,9 @@ describe('typed mongoose', () => {
 			const schema2 = mgoose.generateSchema(MyClass2, {});
 			const baseSchema = mgoose.generateSchema(BaseSchema, {});
 
-			expect(Object.keys(schema1)).be.deep.equal(['otherProp1', 'createdAt', 'updatedAt']);
-			expect(Object.keys(schema2)).be.deep.equal(['otherProp2', 'createdAt', 'updatedAt']);
-			expect(Object.keys(baseSchema)).be.deep.equal(['createdAt', 'updatedAt']);
+			expect(Object.keys(schema1.obj)).be.deep.equal(['otherProp1', 'createdAt', 'updatedAt']);
+			expect(Object.keys(schema2.obj)).be.deep.equal(['otherProp2', 'createdAt', 'updatedAt']);
+			expect(Object.keys(baseSchema.obj)).be.deep.equal(['createdAt', 'updatedAt']);
 		});
 	});
 
@@ -326,6 +326,21 @@ describe('typed mongoose', () => {
 			expect(schema.options).to.containSubset({ timestamps: true, id: true, _id: true });
 			// @ts-ignore
 			expect(schema.path('items').schema.options).to.containSubset({ timestamps: false, id: false, _id: false });
+		});
+
+		it('should allow omitting the schema decorator for classes passed explicitely to generateSchema', () => {
+			class Customer {
+				@mgoose.prop()
+				firstname: string;
+				@mgoose.prop()
+				age: number;
+				@mgoose.prop()
+				isActive: boolean;
+			}
+
+			const schema = mgoose.generateSchema(Customer, {});
+
+			expect(schema).to.be.instanceOf(Schema);
 		});
 	});
 

--- a/packages/mongoose/test/unit/hooks.test.ts
+++ b/packages/mongoose/test/unit/hooks.test.ts
@@ -21,7 +21,7 @@ describe('mongoose hooks', () => {
 	let afterWriteCallback;
 	let beforeDeleteCallback;
 	let afterDeleteCallback;
-	const davinciCtx = { accountId: '123123' };
+	const davinciContext = { accountId: '123123' };
 	const customersData = [{ firstname: 'Mike' }, { firstname: 'John' }];
 
 	beforeEach(async () => {
@@ -74,16 +74,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.find({}, null, { davinciCtx }).countDocuments();
+			await CustomerModel.find({}, null, { davinciContext }).countDocuments();
 			const beforeArgs = beforeReadCallback.getCall(0).args[0];
 			const afterArgs = afterReadCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeArgs).to.containSubset({ hookName: 'countDocuments', davinciCtx });
+			expect(beforeArgs).to.containSubset({ hookName: 'countDocuments', davinciContext });
 			expect(beforeArgs).have.property('query');
 
 			expect(afterReadCallback.callCount).be.equal(1);
-			expect(afterArgs).to.containSubset({ hookName: 'countDocuments', count: 2, davinciCtx });
+			expect(afterArgs).to.containSubset({ hookName: 'countDocuments', count: 2, davinciContext });
 			expect(afterArgs).have.property('query');
 		});
 	});
@@ -92,16 +92,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.find({}, null, { davinciCtx });
+			await CustomerModel.find({}, null, { davinciContext });
 			const beforeArgs = beforeReadCallback.getCall(0).args[0];
 			const afterArgs = afterReadCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeArgs).to.containSubset({ hookName: 'find', davinciCtx });
+			expect(beforeArgs).to.containSubset({ hookName: 'find', davinciContext });
 			expect(beforeArgs).have.property('query');
 
 			expect(afterReadCallback.callCount).be.equal(1);
-			expect(afterArgs).to.containSubset({ hookName: 'find', davinciCtx });
+			expect(afterArgs).to.containSubset({ hookName: 'find', davinciContext });
 			expect(afterArgs).have.property('query');
 			expect(afterArgs).have.property('result').length(2);
 		});
@@ -111,16 +111,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.findOne({ firstname: 'Mike' }, null, { davinciCtx });
+			await CustomerModel.findOne({ firstname: 'Mike' }, null, { davinciContext });
 			const beforeArgs = beforeReadCallback.getCall(0).args[0];
 			const afterArgs = afterReadCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeArgs).to.containSubset({ hookName: 'findOne', davinciCtx });
+			expect(beforeArgs).to.containSubset({ hookName: 'findOne', davinciContext });
 			expect(beforeArgs).have.property('query');
 
 			expect(afterReadCallback.callCount).be.equal(1);
-			expect(afterArgs).to.containSubset({ hookName: 'findOne', davinciCtx });
+			expect(afterArgs).to.containSubset({ hookName: 'findOne', davinciContext });
 			expect(afterArgs).have.property('query');
 			expect(afterArgs).have.property('result').to.containSubset({ firstname: 'Mike' });
 		});
@@ -133,7 +133,7 @@ describe('mongoose hooks', () => {
 			await CustomerModel.findOneAndUpdate(
 				{ firstname: 'Mike' },
 				{ firstname: 'Michael' },
-				{ davinciCtx, new: true }
+				{ davinciContext, new: true }
 			);
 			const beforeReadArgs = beforeReadCallback.getCall(0).args[0];
 			const afterReadArgs = afterReadCallback.getCall(0).args[0];
@@ -142,20 +142,20 @@ describe('mongoose hooks', () => {
 			const afterWriteArgs = afterWriteCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeReadArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciCtx });
+			expect(beforeReadArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciContext });
 			expect(beforeReadArgs).have.property('query');
 
 			expect(afterReadCallback.callCount).be.equal(1);
-			expect(afterReadArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciCtx });
+			expect(afterReadArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciContext });
 			expect(afterReadArgs).have.property('query');
 			expect(afterReadArgs).have.property('result').to.containSubset({ firstname: 'Michael' });
 
 			expect(beforeWriteCallback.callCount).be.equal(1);
-			expect(beforeWriteArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciCtx });
+			expect(beforeWriteArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciContext });
 			expect(beforeWriteArgs).have.property('query');
 
 			expect(afterWriteCallback.callCount).be.equal(1);
-			expect(afterWriteArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciCtx });
+			expect(afterWriteArgs).to.containSubset({ hookName: 'findOneAndUpdate', davinciContext });
 			expect(afterWriteArgs).have.property('query');
 			expect(afterWriteArgs).have.property('result').to.containSubset({ firstname: 'Michael' });
 		});
@@ -165,22 +165,22 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true, write: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.update({ firstname: 'Mike' }, { firstname: 'Michael' }, { davinciCtx, new: true });
+			await CustomerModel.update({ firstname: 'Mike' }, { firstname: 'Michael' }, { davinciContext, new: true });
 			const beforeReadArgs = beforeReadCallback.getCall(0).args[0];
 
 			const beforeWriteArgs = beforeWriteCallback.getCall(0).args[0];
 			const afterWriteArgs = afterWriteCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeReadArgs).to.containSubset({ hookName: 'update', davinciCtx });
+			expect(beforeReadArgs).to.containSubset({ hookName: 'update', davinciContext });
 			expect(beforeReadArgs).have.property('query');
 
 			expect(beforeWriteCallback.callCount).be.equal(1);
-			expect(beforeWriteArgs).to.containSubset({ hookName: 'update', davinciCtx });
+			expect(beforeWriteArgs).to.containSubset({ hookName: 'update', davinciContext });
 			expect(beforeWriteArgs).have.property('query');
 
 			expect(afterWriteCallback.callCount).be.equal(1);
-			expect(afterWriteArgs).to.containSubset({ hookName: 'update', davinciCtx });
+			expect(afterWriteArgs).to.containSubset({ hookName: 'update', davinciContext });
 			expect(afterWriteArgs).have.property('query');
 			expect(afterWriteArgs).have.property('rawResult');
 		});
@@ -190,22 +190,26 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true, write: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.updateMany({ firstname: 'Mike' }, { firstname: 'Michael' }, { davinciCtx, new: true });
+			await CustomerModel.updateMany(
+				{ firstname: 'Mike' },
+				{ firstname: 'Michael' },
+				{ davinciContext, new: true }
+			);
 			const beforeReadArgs = beforeReadCallback.getCall(0).args[0];
 
 			const beforeWriteArgs = beforeWriteCallback.getCall(0).args[0];
 			const afterWriteArgs = afterWriteCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeReadArgs).to.containSubset({ hookName: 'updateMany', davinciCtx });
+			expect(beforeReadArgs).to.containSubset({ hookName: 'updateMany', davinciContext });
 			expect(beforeReadArgs).have.property('query');
 
 			expect(beforeWriteCallback.callCount).be.equal(1);
-			expect(beforeWriteArgs).to.containSubset({ hookName: 'updateMany', davinciCtx });
+			expect(beforeWriteArgs).to.containSubset({ hookName: 'updateMany', davinciContext });
 			expect(beforeWriteArgs).have.property('query');
 
 			expect(afterWriteCallback.callCount).be.equal(1);
-			expect(afterWriteArgs).to.containSubset({ hookName: 'updateMany', davinciCtx });
+			expect(afterWriteArgs).to.containSubset({ hookName: 'updateMany', davinciContext });
 			expect(afterWriteArgs).have.property('query');
 			expect(afterWriteArgs).have.property('rawResult');
 		});
@@ -215,22 +219,26 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ read: true, write: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.updateOne({ firstname: 'Mike' }, { firstname: 'Michael' }, { davinciCtx, new: true });
+			await CustomerModel.updateOne(
+				{ firstname: 'Mike' },
+				{ firstname: 'Michael' },
+				{ davinciContext, new: true }
+			);
 			const beforeReadArgs = beforeReadCallback.getCall(0).args[0];
 
 			const beforeWriteArgs = beforeWriteCallback.getCall(0).args[0];
 			const afterWriteArgs = afterWriteCallback.getCall(0).args[0];
 
 			expect(beforeReadCallback.callCount).be.equal(1);
-			expect(beforeReadArgs).to.containSubset({ hookName: 'updateOne', davinciCtx });
+			expect(beforeReadArgs).to.containSubset({ hookName: 'updateOne', davinciContext });
 			expect(beforeReadArgs).have.property('query');
 
 			expect(beforeWriteCallback.callCount).be.equal(1);
-			expect(beforeWriteArgs).to.containSubset({ hookName: 'updateOne', davinciCtx });
+			expect(beforeWriteArgs).to.containSubset({ hookName: 'updateOne', davinciContext });
 			expect(beforeWriteArgs).have.property('query');
 
 			expect(afterWriteCallback.callCount).be.equal(1);
-			expect(afterWriteArgs).to.containSubset({ hookName: 'updateOne', davinciCtx });
+			expect(afterWriteArgs).to.containSubset({ hookName: 'updateOne', davinciContext });
 			expect(afterWriteArgs).have.property('query');
 			expect(afterWriteArgs).have.property('rawResult');
 		});
@@ -240,16 +248,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ delete: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.findOneAndDelete({ firstname: 'Mike' }, { davinciCtx });
+			await CustomerModel.findOneAndDelete({ firstname: 'Mike' }, { davinciContext });
 			const beforeDeleteArgs = beforeDeleteCallback.getCall(0).args[0];
 			const afterDeleteArgs = afterDeleteCallback.getCall(0).args[0];
 
 			expect(beforeDeleteCallback.callCount).be.equal(1);
-			expect(beforeDeleteArgs).to.containSubset({ hookName: 'findOneAndDelete', davinciCtx });
+			expect(beforeDeleteArgs).to.containSubset({ hookName: 'findOneAndDelete', davinciContext });
 			expect(beforeDeleteArgs).have.property('query');
 
 			expect(afterDeleteCallback.callCount).be.equal(1);
-			expect(afterDeleteArgs).to.containSubset({ hookName: 'findOneAndDelete', davinciCtx });
+			expect(afterDeleteArgs).to.containSubset({ hookName: 'findOneAndDelete', davinciContext });
 			expect(afterDeleteArgs).have.property('query');
 			expect(afterDeleteArgs).have.property('result').to.containSubset({ firstname: 'Mike' });
 			expect(await CustomerModel.findOne({ firstname: 'Mike' })).be.null;
@@ -260,16 +268,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ delete: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.findOneAndRemove({ firstname: 'Mike' }, { davinciCtx });
+			await CustomerModel.findOneAndRemove({ firstname: 'Mike' }, { davinciContext });
 			const beforeDeleteArgs = beforeDeleteCallback.getCall(0).args[0];
 			const afterDeleteArgs = afterDeleteCallback.getCall(0).args[0];
 
 			expect(beforeDeleteCallback.callCount).be.equal(1);
-			expect(beforeDeleteArgs).to.containSubset({ hookName: 'findOneAndRemove', davinciCtx });
+			expect(beforeDeleteArgs).to.containSubset({ hookName: 'findOneAndRemove', davinciContext });
 			expect(beforeDeleteArgs).have.property('query');
 
 			expect(afterDeleteCallback.callCount).be.equal(1);
-			expect(afterDeleteArgs).to.containSubset({ hookName: 'findOneAndRemove', davinciCtx });
+			expect(afterDeleteArgs).to.containSubset({ hookName: 'findOneAndRemove', davinciContext });
 			expect(afterDeleteArgs).have.property('query');
 			expect(afterDeleteArgs).have.property('result').to.containSubset({ firstname: 'Mike' });
 			expect(await CustomerModel.findOne({ firstname: 'Mike' })).be.null;
@@ -280,16 +288,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ delete: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.deleteOne({ firstname: 'Mike' }).setOptions({ davinciCtx });
+			await CustomerModel.deleteOne({ firstname: 'Mike' }).setOptions({ davinciContext });
 			const beforeDeleteArgs = beforeDeleteCallback.getCall(0).args[0];
 			const afterDeleteArgs = afterDeleteCallback.getCall(0).args[0];
 
 			expect(beforeDeleteCallback.callCount).be.equal(1);
-			expect(beforeDeleteArgs).to.containSubset({ hookName: 'deleteOne', davinciCtx });
+			expect(beforeDeleteArgs).to.containSubset({ hookName: 'deleteOne', davinciContext });
 			expect(beforeDeleteArgs).have.property('query');
 
 			expect(afterDeleteCallback.callCount).be.equal(1);
-			expect(afterDeleteArgs).to.containSubset({ hookName: 'deleteOne', davinciCtx });
+			expect(afterDeleteArgs).to.containSubset({ hookName: 'deleteOne', davinciContext });
 			expect(afterDeleteArgs).have.property('query');
 			expect(afterDeleteArgs).have.property('rawResult');
 			expect(await CustomerModel.findOne({ firstname: 'Mike' })).be.null;
@@ -300,16 +308,16 @@ describe('mongoose hooks', () => {
 		registerReadHooks({ delete: true });
 
 		it('should correctly trigger the hooks', async () => {
-			await CustomerModel.deleteMany({ firstname: 'Mike' }).setOptions({ davinciCtx });
+			await CustomerModel.deleteMany({ firstname: 'Mike' }).setOptions({ davinciContext });
 			const beforeDeleteArgs = beforeDeleteCallback.getCall(0).args[0];
 			const afterDeleteArgs = afterDeleteCallback.getCall(0).args[0];
 
 			expect(beforeDeleteCallback.callCount).be.equal(1);
-			expect(beforeDeleteArgs).to.containSubset({ hookName: 'deleteMany', davinciCtx });
+			expect(beforeDeleteArgs).to.containSubset({ hookName: 'deleteMany', davinciContext });
 			expect(beforeDeleteArgs).have.property('query');
 
 			expect(afterDeleteCallback.callCount).be.equal(1);
-			expect(afterDeleteArgs).to.containSubset({ hookName: 'deleteMany', davinciCtx });
+			expect(afterDeleteArgs).to.containSubset({ hookName: 'deleteMany', davinciContext });
 			expect(afterDeleteArgs).have.property('query');
 			expect(afterDeleteArgs).have.property('rawResult');
 			expect(await CustomerModel.findOne({ firstname: 'Mike' })).be.null;
@@ -323,17 +331,17 @@ describe('mongoose hooks', () => {
 			const customer = await CustomerModel.findOne({ firstname: 'Mike' }, null, { skipHooks: true });
 			customer.firstname = 'Michael';
 
-			await customer.save({ davinciCtx });
+			await customer.save({ davinciContext });
 
 			const beforeWriteArgs = beforeWriteCallback.getCall(0).args[0];
 			const afterWriteArgs = afterWriteCallback.getCall(0).args[0];
 
 			expect(beforeWriteCallback.callCount).be.equal(1);
-			expect(beforeWriteArgs).to.containSubset({ hookName: 'save', davinciCtx });
+			expect(beforeWriteArgs).to.containSubset({ hookName: 'save', davinciContext });
 			expect(beforeWriteArgs).have.property('doc').have.property('firstname').equal('Michael');
 
 			expect(afterWriteCallback.callCount).be.equal(1);
-			expect(afterWriteArgs).to.containSubset({ hookName: 'save', davinciCtx });
+			expect(afterWriteArgs).to.containSubset({ hookName: 'save', davinciContext });
 			expect(afterWriteArgs).have.property('result').have.property('firstname').equal('Michael');
 		});
 	});
@@ -344,7 +352,7 @@ describe('mongoose hooks', () => {
 		it('should correctly trigger the hooks', async () => {
 			const customer = await CustomerModel.findOne({ firstname: 'Mike' }, null, { skipHooks: true });
 
-			await customer.remove({ davinciCtx });
+			await customer.remove({ davinciContext });
 
 			const beforeDeleteArgs = beforeDeleteCallback.getCall(0).args[0];
 			const afterDeleteArgs = afterDeleteCallback.getCall(0).args[0];


### PR DESCRIPTION
# Changes included
- renamed davinciCtx to davinciContext (latest from master branch)
- generateSchema now instantiates a new Mongoose Schema by default
- added typing for passing davinciContext within the mongoose query options