### PR TITLE
feat(OpenAPI): added logic for generating or providing operationId

### DIFF
--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -8,6 +8,13 @@ export * from './OpenAPIModule';
 declare module '@davinci/http-server' {
 	interface MethodDecoratorOptions {
 		/**
+		 * specify an operationId explicitly.
+		 * Otherwise, the operationId will be inferred by
+		 * controller + method names
+		 *
+		 */
+		operationId?: string;
+		/**
 		 * if set to 'true' hides the endpoint from the
 		 * generated OpenAPI document
 		 *


### PR DESCRIPTION
### Changes
- added new option `automaticOperationIds` that enable/disable the logic to generate the operationIds using the format `${controllerName}${methodName}`. E.g: `customerFindAll`
- added new option `operationIdFormatter`, which allows specifying a custom logic for the operationId generation
- added the ability to specify it explicitly by passing the `operationId` property within the `@route.method()` decorator