### PR TITLE
feat(Amqp): provide ability to inject ChannelManager in controllers

### DIFF
--- a/examples/next-amqp/src/subscribers/customer/customer.subscriber.ts
+++ b/examples/next-amqp/src/subscribers/customer/customer.subscriber.ts
@@ -4,12 +4,18 @@
  */
 
 import type { ChannelWrapper } from '@davinci/messaging-amqp';
+import { ChannelManager } from '@davinci/messaging-amqp';
 import { channelParam, message, payload, subscribe } from '@davinci/messaging';
-import { interceptor } from '@davinci/core';
+import { di, interceptor } from '@davinci/core';
 import { newrelicInterceptor } from '../../interceptors/newrelic';
 import { Customer } from './customer.schema';
 
+// the injectable decorator is required to inject the dependencies
+// listed in the constructor
+@di.injectable()
 export default class CustomerSubscriber {
+	constructor(private channelManager?: ChannelManager) {}
+
 	@subscribe({
 		name: 'subscribeCustomerChange',
 		amqp: {
@@ -19,7 +25,13 @@ export default class CustomerSubscriber {
 		}
 	})
 	@interceptor(newrelicInterceptor())
-	subscribeCustomerChange(@message() msg, @payload() customer: Customer, @channelParam() channel: ChannelWrapper) {
-		return { msg, customer, channel };
+	async subscribeCustomerChange(
+		@message() msg,
+		@payload() customer: Customer,
+		@channelParam() channel: ChannelWrapper
+	) {
+		await this.channelManager.publish('exchange2', {}, 'topic2');
+
+		return { msg, customer, channel, channelManager: this.channelManager };
 	}
 }

--- a/packages/core/test/unit/App.test.ts
+++ b/packages/core/test/unit/App.test.ts
@@ -143,26 +143,9 @@ describe('App', () => {
 
 		const controllersReflection = app.getControllersWithReflection();
 
-		expect(controllersReflection).to.be.deep.equal([
-			{ Controller: MyController, reflection: myControllerReflection }
-		]);
-	});
-
-	it('should cache the reflection result', () => {
-		@decorate({ isMyClass: true })
-		class MyController {
-			@decorate({ isMyMethod: true })
-			myMethod(@decorateParameter({ isMyParam: true }) param: string) {
-				return param;
-			}
-		}
-		const app = createApp({ controllers: [MyController] });
-
-		const getControllerReflectionSpy = sinon.spy(app, 'getControllerReflection');
-		app.getControllersWithReflection();
-		app.getControllersWithReflection();
-
-		expect(getControllerReflectionSpy.callCount).to.be.equal(1);
+		expect(controllersReflection[0].Controller).to.be.deep.equal(MyController);
+		expect(controllersReflection[0].reflection).to.be.deep.equal(myControllerReflection);
+		expect(controllersReflection[0].controllerInstance).to.be.instanceof(MyController);
 	});
 
 	it('should execute the onInit hook', async () => {

--- a/packages/messaging-amqp/src/AmqpModule.ts
+++ b/packages/messaging-amqp/src/AmqpModule.ts
@@ -31,6 +31,7 @@ export interface AmqpModuleOptions {
 	connectionTimeout?: number;
 	subscriptions?: Array<AmqpSubscriptionSettings>;
 	defaultSubscriptionSettings?: PartialDeep<AmqpSubscriptionSettings>;
+	defaultChannelSettings?: AmqpSubscriptionSettings;
 	gracefulShutdownStrategy?: 'none' | 'processInFlight' | 'nackInFlight' | null;
 	channelManagerFactory?: (connection: AmqpConnectionManager, options: ChannelManagerOptions) => ChannelManager;
 	logger?: {
@@ -58,7 +59,14 @@ export class AmqpModule extends Module {
 
 	constructor(options: AmqpModuleOptions) {
 		super();
-		this.options = deepmerge({ connectionTimeout: 5000, logger: { name: 'AmqpModule', level: 'info' } }, options);
+		this.options = deepmerge(
+			<AmqpModuleOptions>{
+				connectionTimeout: 5000,
+				defaultChannelSettings: { exchangeType: 'topic' },
+				logger: { name: 'AmqpModule', level: 'info' }
+			},
+			options
+		);
 		this.bus = new EventEmitter();
 		this.logger = pino({ name: this.options.logger?.name });
 		this.logger.level = this.options.logger?.level;
@@ -75,7 +83,10 @@ export class AmqpModule extends Module {
 		this.connection = amqpConnectionManager.connect(connectionOptions, this.options.connectionManagerOptions);
 		this.channelManager =
 			this.options.channelManagerFactory?.(this.connection, { logger: this.options.logger }) ??
-			new ChannelManager(this.connection, { logger: this.options.logger });
+			di.container.resolve(ChannelManager).setConnection(this.connection).setOptions({
+				defaultChannelSettings: this.options.defaultChannelSettings,
+				logger: this.options.logger
+			});
 	}
 
 	async onInit() {
@@ -130,13 +141,12 @@ export class AmqpModule extends Module {
 			}
 		>();
 
-		this.app.getControllersWithReflection().forEach(({ Controller, reflection }) => {
+		this.app.getControllersWithReflection().forEach(({ controllerInstance, reflection }) => {
 			const matches = this.findMatchingMethodAndDecoratorReflections(reflection);
 
 			matches.forEach(({ methodReflection, decorator }) => {
-				const controller = di.container.resolve(Controller);
 				const controllerMethodAndReflections = {
-					controller,
+					controller: controllerInstance,
 					controllerReflection: reflection,
 					methodReflection
 				};

--- a/packages/messaging-amqp/src/index.ts
+++ b/packages/messaging-amqp/src/index.ts
@@ -6,6 +6,7 @@
 import { AmqpSubscribeOptions } from './types';
 
 export * from './AmqpModule';
+export * from './ChannelManager';
 export * from './types';
 
 declare module '@davinci/messaging' {

--- a/packages/messaging-amqp/test/integration/AmqpModule.test.ts
+++ b/packages/messaging-amqp/test/integration/AmqpModule.test.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 import { createSandbox } from 'sinon';
-import { App, interceptor, mapSeries, nextTick } from '@davinci/core';
+import { App, di, interceptor, mapSeries, nextTick } from '@davinci/core';
 import { channelParam, message, payload, subscribe } from '@davinci/messaging';
-import { AmqpInterceptor, AmqpModule, AmqpModuleOptions, Subscription } from '../../src';
+import { AmqpInterceptor, AmqpModule, AmqpModuleOptions, ChannelManager, Subscription } from '../../src';
 import { expect } from '../support/chai';
 
 const sinon = createSandbox();
@@ -56,6 +56,7 @@ describe('AmqpModule', () => {
 		await app?.shutdown();
 		app = null;
 		sinon.restore();
+		di.container.clearInstances();
 	});
 
 	describe('initialization', () => {
@@ -354,6 +355,96 @@ describe('AmqpModule', () => {
 		});
 	});
 
+	describe.skip('ChannelManager', () => {
+		it('should inject the channelManager within the controller and publish a message', async () => {
+			@di.injectable()
+			class MyController {
+				constructor(private channelManager?: ChannelManager) {}
+
+				@subscribe({
+					name: 'mySubscription1',
+					amqp: {
+						exchange: 'testExchange1',
+						topic: 'testTopic',
+						queue: 'testQueue',
+						queueOptions: { autoDelete: true }
+					}
+				})
+				async handler1() {
+					await this.channelManager.publish('testExchange2', {}, 'testTopic');
+					return { success: true };
+				}
+
+				@subscribe({
+					name: 'mySubscription2',
+					amqp: {
+						exchange: 'testExchange2',
+						topic: 'testTopic',
+						queue: 'testQueue',
+						queueOptions: { autoDelete: true }
+					}
+				})
+				handler2() {
+					return { success: true };
+				}
+			}
+
+			const handler1Spy = sinon.spy(MyController.prototype, 'handler1');
+			const handler2Spy = sinon.spy(MyController.prototype, 'handler2');
+
+			const { amqpModule } = await initApp(MyController, {
+				defaultSubscriptionSettings: { autoAck: true }
+			});
+
+			const subscription = amqpModule.getSubscriptions()[0];
+
+			// publish a message
+			const messageContent = {};
+			await subscription.channel.publish('testExchange1', 'testTopic', messageContent);
+			await delay(() => {}, 100);
+
+			// assert
+			expect(handler1Spy.called).to.be.true;
+			expect(handler2Spy.called).to.be.true;
+		});
+
+		it('should be able to publish messages', async () => {
+			@di.injectable()
+			class MyController {
+				constructor(private channelManager?: ChannelManager) {}
+
+				@subscribe({
+					name: 'mySubscription',
+					amqp: {
+						exchange: 'testExchange',
+						topic: 'testTopic',
+						queue: 'testQueue',
+						queueOptions: { autoDelete: true }
+					}
+				})
+				handler() {
+					return { channelManager: this.channelManager };
+				}
+			}
+
+			const { amqpModule, handlerSpy } = await initApp(MyController, {
+				defaultSubscriptionSettings: { autoAck: true }
+			});
+
+			const subscription = amqpModule.getSubscriptions()[0];
+
+			// publish a message
+			const messageContent = {};
+			await subscription.channel.publish('testExchange', 'testTopic', messageContent);
+			await nextTick(() => handlerSpy.called);
+
+			// assert
+			const returnValue = handlerSpy.getCall(0).returnValue;
+
+			expect(returnValue.channelManager).to.be.instanceof(ChannelManager);
+		});
+	});
+
 	describe('shutdown', () => {
 		it('should wait until all in-flight messages are processed', async () => {
 			class MyController {
@@ -367,7 +458,7 @@ describe('AmqpModule', () => {
 					}
 				})
 				async handler(@message() msg, @payload() body, @channelParam() channel) {
-					await new Promise(resolve => setTimeout(() => resolve(null), 1000));
+					await delay(() => {}, 1000);
 					return { msg, body, channel };
 				}
 			}
@@ -409,7 +500,7 @@ describe('AmqpModule', () => {
 					}
 				})
 				async handler(@message() msg, @payload() body, @channelParam() channel) {
-					await new Promise(resolve => setTimeout(() => resolve(null), 1000));
+					await delay(() => {}, 500);
 					return { msg, body, channel };
 				}
 			}

--- a/packages/messaging-amqp/test/integration/AmqpModule.test.ts
+++ b/packages/messaging-amqp/test/integration/AmqpModule.test.ts
@@ -355,7 +355,7 @@ describe('AmqpModule', () => {
 		});
 	});
 
-	describe.skip('ChannelManager', () => {
+	describe('ChannelManager', () => {
 		it('should inject the channelManager within the controller and publish a message', async () => {
 			@di.injectable()
 			class MyController {


### PR DESCRIPTION
## Changes
Added the ability to inject the ChannelManager within the Controllers and other classes where needed, so that publishing messages is trivial.


### Other notable changes:
- Instantiating controllers in App
- removed reflection cache in App as already provided by @plumier/reflect