### PR TITLE
fix(mongoose): set typeKey schema option to '$type'

### DIFF
--- a/packages/core/src/lib/object-utils.ts
+++ b/packages/core/src/lib/object-utils.ts
@@ -16,6 +16,7 @@ export function mapObject(obj: object, iteratee: (value, key: string) => unknown
 export function omit<T extends object>(obj: T, keys: (keyof T)[]): Partial<T>;
 export function omit(obj: object, keys: string[]) {
 	if (!keys.length) return obj;
+	if (typeof obj !== 'object' || obj === null) return obj;
 
 	return Object.keys(obj).reduce((acc, key) => {
 		if (keys.indexOf(key) === -1) {

--- a/packages/core/test/unit/lib/object-utils.tests.ts
+++ b/packages/core/test/unit/lib/object-utils.tests.ts
@@ -46,6 +46,11 @@ describe('object-utils', () => {
 
 			expect(result).to.be.deep.equal(input);
 		});
+
+		it('should handle null or undefined', () => {
+			expect(omit(null, [])).to.be.equal(null);
+			expect(omit(undefined, [])).to.be.equal(undefined);
+		});
 	});
 
 	describe('#isPlainObject', () => {

--- a/packages/mongoose/src/generateModel.ts
+++ b/packages/mongoose/src/generateModel.ts
@@ -5,6 +5,7 @@
 
 import { model, Model, Schema, SchemaOptions } from 'mongoose';
 import { ClassType, DecoratorId, PropertyReflection, reflect, TypeValue } from '@davinci/reflector';
+import { omit } from '@davinci/core';
 import { IPropDecoratorOptions, IPropDecoratorOptionsFactory } from './decorators/types';
 
 /**
@@ -93,8 +94,8 @@ export const generateSchema = <T>(
 			}
 
 			const prop = {
-				...options,
-				type
+				...omit(options, ['type']),
+				$type: type
 			};
 
 			return {
@@ -106,7 +107,9 @@ export const generateSchema = <T>(
 		// get schema options
 		const schemaDecoration = classReflection.decorators.find(d => d[DecoratorId] === 'mongoose.schema');
 		const schemaOptions = schemaDecoration?.options;
-		const schema = (forceCreateSchema || schemaDecoration) && new Schema(definition, options ?? schemaOptions);
+		const schema =
+			(forceCreateSchema || schemaDecoration) &&
+			new Schema(definition, { ...(options ?? schemaOptions), typeKey: '$type' });
 
 		// register methods
 		const methods = classReflection.methods.reduce((acc, methodReflection) => {

--- a/packages/mongoose/test/unit/generateModel.test.ts
+++ b/packages/mongoose/test/unit/generateModel.test.ts
@@ -30,13 +30,13 @@ describe('typed mongoose', () => {
 
 			expect(schema.obj).to.be.deep.equal({
 				firstname: {
-					type: String
+					$type: String
 				},
 				age: {
-					type: Number
+					$type: Number
 				},
 				isActive: {
-					type: Boolean
+					$type: Boolean
 				}
 			});
 		});
@@ -56,9 +56,9 @@ describe('typed mongoose', () => {
 
 			expect(schema.obj).to.be.deep.equal({
 				birth: {
-					type: {
+					$type: {
 						place: {
-							type: String
+							$type: String
 						}
 					}
 				}
@@ -84,14 +84,14 @@ describe('typed mongoose', () => {
 			expect(schema.obj).to.be.deep.equal({
 				birth: [
 					{
-						type: {
+						$type: {
 							place: {
-								type: String
+								$type: String
 							}
 						}
 					}
 				],
-				tags: [{ type: String }]
+				tags: [{ $type: String }]
 			});
 		});
 
@@ -120,6 +120,51 @@ describe('typed mongoose', () => {
 			expect(Object.keys(schema1.obj)).be.deep.equal(['otherProp1', 'createdAt', 'updatedAt']);
 			expect(Object.keys(schema2.obj)).be.deep.equal(['otherProp2', 'createdAt', 'updatedAt']);
 			expect(Object.keys(baseSchema.obj)).be.deep.equal(['createdAt', 'updatedAt']);
+		});
+
+		it('supports nested properties with name "type"', () => {
+			class Phones {
+				@mgoose.prop()
+				type: string;
+
+				@mgoose.prop()
+				number: string;
+			}
+
+			class Profile {
+				@mgoose.prop()
+				name: string;
+
+				@mgoose.prop({ type: [Phones], required: true })
+				phones: Phones[];
+			}
+
+			class Customer {
+				@mgoose.prop({ type: [Profile], required: true })
+				profiles: Profile[];
+			}
+
+			const schema = mgoose.generateSchema(Customer, {});
+
+			expect(schema.obj).to.be.deep.equal({
+				profiles: [
+					{
+						required: true,
+						$type: {
+							name: { $type: String },
+							phones: [
+								{
+									required: true,
+									$type: {
+										type: { $type: String },
+										number: { $type: String }
+									}
+								}
+							]
+						}
+					}
+				]
+			});
 		});
 	});
 


### PR DESCRIPTION
## Motivation
The changes included in the PR solve an issue when creating schemas having properties with field name 'type'.
That clashes with the internal `type` used to define the SchemaType.

To avoid the clashing, the typeKey value has been set to `$type`