### PR TITLE
fit: revert mongoose typekey

### DIFF
--- a/packages/core/src/entity/jsonSchemaTypes.ts
+++ b/packages/core/src/entity/jsonSchemaTypes.ts
@@ -139,6 +139,7 @@ export type UncheckedJSONSchemaType<T, IsPartial extends boolean> = (
 	$ref?: string;
 	$defs?: Record<string, UncheckedJSONSchemaType<Known, true>>;
 	definitions?: Record<string, UncheckedJSONSchemaType<Known, true>>;
+	default?: unknown;
 };
 
 export type JSONSchemaType<T> = StrictNullChecksWrapper<'JSONSchemaType', UncheckedJSONSchemaType<T, false>>;

--- a/packages/mongoose/src/decorators/types.ts
+++ b/packages/mongoose/src/decorators/types.ts
@@ -6,11 +6,11 @@
 import { SchemaTypeOptions } from 'mongoose';
 import { Maybe, TypeValue, TypeValueFactory } from '@davinci/reflector';
 
-export interface IPropDecoratorOptions extends Omit<SchemaTypeOptions<any>, 'type'> {
-	typeFactory?: TypeValueFactory;
+export type IPropDecoratorOptions = SchemaTypeOptions<any> & {
 	type?: TypeValue;
+	typeFactory?: TypeValueFactory;
 	rawType?: any;
-}
+};
 
 export type IPropDecoratorOptionsFactory = () => Maybe<IPropDecoratorOptions>;
 

--- a/packages/mongoose/src/generateModel.ts
+++ b/packages/mongoose/src/generateModel.ts
@@ -96,7 +96,7 @@ export const generateSchema = <T>(
 
 			const prop = {
 				...omit(options, ['type']),
-				$type: type
+				type
 			};
 
 			return {
@@ -109,8 +109,7 @@ export const generateSchema = <T>(
 		const schemaDecoration = classReflection.decorators.find(d => d[DecoratorId] === 'mongoose.schema');
 		const schemaOptions = schemaDecoration?.options;
 		const schema =
-			(forceCreateSchema || schemaDecoration) &&
-			new Schema(definition, { ...(options ?? schemaOptions), typeKey: '$type' });
+			(forceCreateSchema || schemaDecoration) && new Schema(definition, { ...(options ?? schemaOptions) });
 
 		// register methods
 		const methods = classReflection.methods.reduce((acc, methodReflection) => {

--- a/packages/mongoose/test/unit/generateModel.test.ts
+++ b/packages/mongoose/test/unit/generateModel.test.ts
@@ -30,13 +30,13 @@ describe('generateModel', () => {
 
 			expect(schema.obj).to.be.deep.equal({
 				firstname: {
-					$type: String
+					type: String
 				},
 				age: {
-					$type: Number
+					type: Number
 				},
 				isActive: {
-					$type: Boolean
+					type: Boolean
 				}
 			});
 		});
@@ -56,9 +56,9 @@ describe('generateModel', () => {
 
 			expect(schema.obj).to.be.deep.equal({
 				birth: {
-					$type: {
+					type: {
 						place: {
-							$type: String
+							type: String
 						}
 					}
 				}
@@ -84,14 +84,14 @@ describe('generateModel', () => {
 			expect(schema.obj).to.be.deep.equal({
 				birth: [
 					{
-						$type: {
+						type: {
 							place: {
-								$type: String
+								type: String
 							}
 						}
 					}
 				],
-				tags: [{ $type: String }]
+				tags: [{ type: String }]
 			});
 		});
 
@@ -122,8 +122,9 @@ describe('generateModel', () => {
 			expect(Object.keys(baseSchema.obj)).be.deep.equal(['createdAt', 'updatedAt']);
 		});
 
-		it('supports nested properties with name "type"', () => {
-			class Phones {
+		/*
+		it('supports nested properties, with name "type"', () => {
+			class Phone {
 				@mgoose.prop()
 				type: string;
 
@@ -131,17 +132,9 @@ describe('generateModel', () => {
 				number: string;
 			}
 
-			class Profile {
-				@mgoose.prop()
-				name: string;
-
-				@mgoose.prop({ type: [Phones], required: true })
-				phones: Phones[];
-			}
-
 			class Customer {
-				@mgoose.prop({ type: [Profile], required: true })
-				profiles: Profile[];
+				@mgoose.prop({ type: [Phone], required: true })
+				phones: Phone[];
 			}
 
 			const schema = mgoose.generateSchema(Customer, {});
@@ -150,14 +143,14 @@ describe('generateModel', () => {
 				profiles: [
 					{
 						required: true,
-						$type: {
-							name: { $type: String },
+						type: {
+							name: { type: String },
 							phones: [
 								{
 									required: true,
-									$type: {
-										type: { $type: String },
-										number: { $type: String }
+									type: {
+										type: { type: String },
+										number: { type: String }
 									}
 								}
 							]
@@ -166,6 +159,7 @@ describe('generateModel', () => {
 				]
 			});
 		});
+*/
 	});
 
 	describe('#mgoose.generateSchema', () => {


### PR DESCRIPTION
## Motivation
This PR reverts a previous change that explicitly set the mongose typeKey to be `$type`, that was introduced in order to support properties name `type`.

Unfortunately, the change breaks the support for keywords on sub-schemas.


### Other changes
Better @mgoose.prop() and @entity.prop() code suggestion