### PR TITLE
feat: added parameter that enables jsonified querystring parsing

### DIFF
--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -82,6 +82,7 @@ export interface HttpServerModuleOptions {
 	errorsHandling?: {
 		exposeStack?: boolean;
 	};
+	querystringJsonParsing?: boolean;
 	globalInterceptors?: Array<HttpServerInterceptor>;
 	logger?: {
 		name?: string;


### PR DESCRIPTION
## Changes
This PR add a new `querystringJsonParsing` parameter that can enable the parsing of jsonified querystring parameters:
e.g.
```
GET /api/customers?query={"where":{"firstname": "John"}}
```