### PR TITLE
fix(openapi) removed http server from peerDependency

### DIFF
--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,7 +27,6 @@
 		"openapi-types": "^12.0.0"
 	},
 	"peerDependencies": {
-		"@davinci/http-server": "^3.0.0",
 		"pino": "^8.7.0"
 	},
 	"devDependencies": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -27,7 +27,7 @@
 		"openapi-types": "^12.0.0"
 	},
 	"peerDependencies": {
-		"@davinci/http-server": "^2.0.0",
+		"@davinci/http-server": "^3.0.0",
 		"pino": "^8.7.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The version mismatch was causing some conflicts.
The http-server dependency was removed altogether

![Screenshot from 2022-12-15 12-23-23](https://user-images.githubusercontent.com/2676481/207850033-e8c7e1da-60a0-4343-9cd3-b1da01d34d41.png)
