### PR TITLE
feat(entity): added support for recursive schemas

### DIFF
--- a/packages/core/test/unit/entity/EntityRegistry.tests.ts
+++ b/packages/core/test/unit/entity/EntityRegistry.tests.ts
@@ -145,20 +145,20 @@ describe('EntityRegistry', () => {
 
 		@entity()
 		class Populate {
-			@entity.prop({ anyOf: [{ type: 'string' }, Populate] })
+			@entity.prop({ type: false, anyOf: [{ type: 'string' }, Populate] })
 			populate: string | Populate;
 		}
 
 		const jsonSchema = entityRegistry.getEntityDefinitionJsonSchema(Populate);
 		const populateEntityDefinition = entityRegistry.getEntityDefinitionMap().get(Populate);
 
-		expect(jsonSchema).to.containSubset({
+		expect(jsonSchema).to.be.containSubset({
 			$id: 'Populate',
 			title: 'Populate',
 			type: 'object',
 			properties: {
 				populate: {
-					_$ref: populateEntityDefinition
+					anyOf: [{ type: 'string' }, { _$ref: populateEntityDefinition }]
 				}
 			}
 		});


### PR DESCRIPTION
## Changes
This PR allows you to use a schema that references itself within an entity. 
```ts
// example 1
@entity()
class Populate {
	@entity.prop()
	populate: Populate;
}

// example 2 -> array
@entity()
class Populate {
	@entity.prop({ type: [Populate] })
	populate: Array<Populate>
}

// example 3 -> nested inside anyOf, allOf, oneOf keywords
@entity()
class Populate {
	@entity.prop({ anyOf: [{ type: 'string' }, Populate] })
	populate: string | Populate;
}
```