### PR TITLE
feat(typeFactory): implemented typeFactory

### DIFF
--- a/examples/api-express/openapi.json
+++ b/examples/api-express/openapi.json
@@ -138,6 +138,26 @@
           },
           "birth": {
             "$ref": "#/components/schemas/Birth"
+          },
+          "orders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            }
+          }
+        }
+      },
+      "Order": {
+        "title": "Order",
+        "type": "object",
+        "required": [],
+        "$id": "Order",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
           }
         }
       }

--- a/examples/api-express/src/api/customer/customer.schema.ts
+++ b/examples/api-express/src/api/customer/customer.schema.ts
@@ -4,6 +4,7 @@
  */
 
 import { entity } from '@davinci/core';
+import { Order } from './order.schema';
 
 class Phone {
 	@entity.prop()
@@ -35,4 +36,7 @@ export class Customer {
 
 	@entity.prop()
 	birth?: Birth;
+
+	@entity.prop({ typeFactory: () => [Order] })
+	orders?: Array<Order>;
 }

--- a/examples/api-express/src/api/customer/order.schema.ts
+++ b/examples/api-express/src/api/customer/order.schema.ts
@@ -1,0 +1,16 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { entity } from '@davinci/core';
+import { Customer } from './customer.schema';
+
+@entity()
+export class Order {
+	@entity.prop()
+	id?: string;
+
+	@entity.prop({ typeFactory: () => Customer })
+	customer?: Customer;
+}

--- a/examples/api-express/test/integration/Customer.tests.ts
+++ b/examples/api-express/test/integration/Customer.tests.ts
@@ -1,5 +1,8 @@
 import { app } from '../../src';
 import { expect } from '../support/chai';
+import { EntityRegistry } from '@davinci/core';
+import { Customer } from '../../src/api/customer/customer.schema';
+import { Book } from '../../src/api/customer/order.schema';
 
 describe('Customer integration tests', () => {
 	before(async () => {
@@ -62,5 +65,12 @@ describe('Customer integration tests', () => {
 				}
 			});
 		});
+	});
+
+	it('should', () => {
+		const entityRegistry = new EntityRegistry();
+		const customerJsonSchema = entityRegistry.getEntityDefinitionJsonSchema(Customer);
+		const bookJsonSchema = entityRegistry.getEntityDefinitionJsonSchema(Book);
+		console.log(customerJsonSchema, bookJsonSchema, Book);
 	});
 });

--- a/examples/api-fastify/src/api/customer/customer.schema.ts
+++ b/examples/api-fastify/src/api/customer/customer.schema.ts
@@ -4,6 +4,7 @@
  */
 
 import { entity } from '@davinci/core';
+import { Order } from './order.schema';
 
 class Phone {
 	@entity.prop()
@@ -35,4 +36,7 @@ export class Customer {
 
 	@entity.prop()
 	birth?: Birth;
+
+	@entity.prop({ typeFactory: () => [Order] })
+	orders?: Array<Order>;
 }

--- a/examples/api-fastify/src/api/customer/order.schema.ts
+++ b/examples/api-fastify/src/api/customer/order.schema.ts
@@ -1,0 +1,16 @@
+/*
+ * © Copyright 2022 HP Development Company, L.P.
+ * SPDX-License-Identifier: MIT
+ */
+
+import { entity } from '@davinci/core';
+import { Customer } from './customer.schema';
+
+@entity()
+export class Order {
+	@entity.prop()
+	id?: string;
+
+	@entity.prop({ typeFactory: () => Customer })
+	customer?: Customer;
+}

--- a/packages/core/src/entity/types.ts
+++ b/packages/core/src/entity/types.ts
@@ -18,6 +18,7 @@ export type EntityDefinitionJSONSchema<T = any> = JSONSchema<T> & { _$ref?: Enti
 
 export type EntityPropOptions<T = unknown> = Partial<JSONSchema<T>> & {
 	type?: TypeValue | JSONSchema<T>['type'];
+	typeFactory?: () => TypeValue | JSONSchema<T>['type'];
 	required?: boolean | string[];
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,8 +15,8 @@ export * from './entity/EntityRegistry';
 export * from './entity/decorators';
 export * from './entity/types';
 export * from './entity/json/transformEntityDefinitionSchema';
-export * from './entity/json/types';
 
+export * from './entity/json/types';
 export * from './lib/async-utils';
 export * from './lib/array-utils';
 export * from './lib/object-utils';

--- a/packages/core/test/support/data/AuthorSchema.ts
+++ b/packages/core/test/support/data/AuthorSchema.ts
@@ -1,0 +1,11 @@
+import { entity } from '../../../src';
+import { Book } from './BookSchema';
+
+@entity()
+export class Author {
+	@entity.prop()
+	name: string;
+
+	@entity.prop({ typeFactory: () => [Book] })
+	books: Array<Book>;
+}

--- a/packages/core/test/support/data/BookSchema.ts
+++ b/packages/core/test/support/data/BookSchema.ts
@@ -1,0 +1,11 @@
+import { entity } from '../../../src';
+import { Author } from './AuthorSchema';
+
+@entity()
+export class Book {
+	@entity.prop()
+	title: string;
+
+	@entity.prop({ typeFactory: () => Author })
+	author: Author;
+}


### PR DESCRIPTION
## What
Added a new 'typeFactory' property in the entity.prop() decorator, that accepts a factory function.
## Why
This will allow for defining schemas with circular dependencies:
#### Example
```ts
// file AuthorSchema.ts
import { entity } from '../../../src';
import { Book } from './BookSchema';

@entity()
export class Author {
	@entity.prop()
	name: string;

	@entity.prop({ typeFactory: () => [Book] })
	books: Array<Book>;
}
```
```ts
// file BookSchema.ts
import { entity } from '../../../src';
import { Author } from './AuthorSchema';

@entity()
export class Book {
	@entity.prop()
	title: string;

	@entity.prop({ typeFactory: () => Author })
	author: Author;
}

```
## How
By specifying a function that returns a function present in the closure scope, the reference to the proxy object is retained.

Note: DaVinci 1.x had this functionality, this PR restores it