### PR TITLE
Fix: do not filter null from enum if marked as nullable

### DIFF
--- a/packages/core/src/entity/EntityDefinition.ts
+++ b/packages/core/src/entity/EntityDefinition.ts
@@ -161,7 +161,7 @@ export class EntityDefinition {
 									additionalSchemaProps = {};
 									additionalSchemaProps.type = enmType;
 									additionalSchemaProps.enum = Object.values(args.schema.enum).filter(
-										v => typeof v === enmType
+										v => typeof v === enmType || (v === null && args.schema.nullable)
 									) as Array<string | number>;
 									hasAdditionalSchemaProps = true;
 								}


### PR DESCRIPTION
There is no current way of allow DaVinci to pass null as enum value (even if provided as part of the values).

To fix it, I've modified the filtering expression to allow null as value if the schema is marked as nullable.
