### PR TITLE
feat(reflector): updated to @plumier/reflect@1.1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ jobs:
     parameters:
       mongo-version:
         type: string
-      node-version:
+      docker-image:
         type: string
     docker:
-      - image: circleci/node:<< parameters.node-version >>
+      - image: << parameters.docker-image >>
       - image: circleci/mongo:<< parameters.mongo-version >>
       - image: rabbitmq:3.9-alpine
     steps:
@@ -40,7 +40,7 @@ jobs:
           condition:
             and:
               - equal: [ "4.4", << parameters.mongo-version >> ]
-              - equal: [ "14", << parameters.node-version >> ]
+              - equal: [ "circleci/node:14", << parameters.docker-image >> ]
           steps:
             - run:
                 name: upload coverage report
@@ -94,7 +94,7 @@ workflows:
           matrix:
             parameters:
               mongo-version: ["4.4", "5"]
-              node-version: ["14", "16"]
+              docker-image: ["circleci/node:14", "circleci/node:16", "cimg/node:18.16.0", "cimg/node:20.3.0"]
       - publish:
           requires:
             - checkout_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
       - when:
           condition:
             and:
-              - equal: [ "4.4", << parameters.mongo-version >> ]
-              - equal: [ "circleci/node:14", << parameters.docker-image >> ]
+              - equal: [ "5", << parameters.mongo-version >> ]
+              - equal: [ "cimg/node:18.16.0", << parameters.docker-image >> ]
           steps:
             - run:
                 name: upload coverage report
@@ -94,7 +94,7 @@ workflows:
           matrix:
             parameters:
               mongo-version: ["4.4", "5"]
-              docker-image: ["circleci/node:14", "circleci/node:16", "cimg/node:18.16.0", "cimg/node:20.3.0"]
+              docker-image: ["circleci/node:14", "circleci/node:16", "cimg/node:18.16.0"]
       - publish:
           requires:
             - checkout_and_test

--- a/packages/reflector/package-lock.json
+++ b/packages/reflector/package-lock.json
@@ -6,20 +6,20 @@
 	"packages": {
 		"": {
 			"name": "@davinci/reflector",
-			"version": "2.1.2",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@plumier/reflect": "1.0.6",
-				"reflect-metadata": "^0.1.13"
+				"@plumier/reflect": "1.1.3",
+				"reflect-metadata": "0.1.13"
 			}
 		},
 		"node_modules/@plumier/reflect": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@plumier/reflect/-/reflect-1.0.6.tgz",
-			"integrity": "sha512-T/wkxlrXZ3qJV07YFC67I5HXlI1E2D7Kmq7skZxu7KEoqjMWrTEpvug2mJ7tze0WeDtPerl9C9m55lk+0+Ipyw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@plumier/reflect/-/reflect-1.1.3.tgz",
+			"integrity": "sha512-27ubBCNh0jiOi6rb+Wzj4HiiibSN/s6PzwjMr597IM47gFjE1HC+FbQE1Mkg0iDFlVsKvA4ksIeBytBQay4KIQ==",
 			"dependencies": {
 				"@types/acorn": "4.0.6",
-				"acorn": "8.5.0",
+				"acorn": "8.8.1",
 				"reflect-metadata": "^0.1.13"
 			}
 		},
@@ -37,9 +37,9 @@
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
 		},
 		"node_modules/acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -55,12 +55,12 @@
 	},
 	"dependencies": {
 		"@plumier/reflect": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@plumier/reflect/-/reflect-1.0.6.tgz",
-			"integrity": "sha512-T/wkxlrXZ3qJV07YFC67I5HXlI1E2D7Kmq7skZxu7KEoqjMWrTEpvug2mJ7tze0WeDtPerl9C9m55lk+0+Ipyw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@plumier/reflect/-/reflect-1.1.3.tgz",
+			"integrity": "sha512-27ubBCNh0jiOi6rb+Wzj4HiiibSN/s6PzwjMr597IM47gFjE1HC+FbQE1Mkg0iDFlVsKvA4ksIeBytBQay4KIQ==",
 			"requires": {
 				"@types/acorn": "4.0.6",
-				"acorn": "8.5.0",
+				"acorn": "8.8.1",
 				"reflect-metadata": "^0.1.13"
 			}
 		},
@@ -78,9 +78,9 @@
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
 		},
 		"acorn": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
 		},
 		"reflect-metadata": {
 			"version": "0.1.13",

--- a/packages/reflector/package.json
+++ b/packages/reflector/package.json
@@ -16,8 +16,8 @@
 	"author": "HP",
 	"license": "MIT",
 	"dependencies": {
-		"@plumier/reflect": "1.0.6",
-		"reflect-metadata": "^0.1.13"
+		"@plumier/reflect": "1.1.3",
+		"reflect-metadata": "0.1.13"
 	},
 	"gitHead": "451fc8dbdbf23b7f019391dcfce5f85c24cd40f4"
 }


### PR DESCRIPTION
### Changes
`@plumier/reflect` in the `reflector` package as been upgraded to v1.1.3

### Motivation
The latest version of `@plumier/reflect` supports configuring the `target` and `lib` properties of the tsconfig.json with modern ES* values, compatible with Node.js v18, as suggested [here](https://github.com/tsconfig/bases/blob/main/bases/node18.json)