### PR TITLE
Fix: fetch git tags before publish to avoid cache issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,10 @@ jobs:
             mkdir -p ~/.ssh
             ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
+          name: refresh git tags
+          command: |
+            git fetch --tags
+      - run:
           name: publish
           command: |
             git config --global user.email "circleci@hp.com"


### PR DESCRIPTION
* Due to circleci cache, tags are not refreshed if in the cache, trying to solve fetching tags before publish step.