### PR TITLE
feat: improve edge compatibility

### DIFF
--- a/packages/http-server/src/HttpServerModule.ts
+++ b/packages/http-server/src/HttpServerModule.ts
@@ -14,7 +14,6 @@ import {
 	Module,
 	omit
 } from '@davinci/core';
-import pathUtils from 'path';
 import pino from 'pino';
 import { ClassReflection, ClassType, DecoratorId, MethodReflection } from '@davinci/reflector';
 import type { InjectOptions } from 'light-my-request';
@@ -130,7 +129,7 @@ export abstract class HttpServerModule<
 						options: { path }
 					} = methodDecoratorMetadata;
 
-					let fullPath = pathUtils.join(basePath, path);
+					let fullPath = this.joinPath(basePath, path);
 					if (fullPath.length > 1 && fullPath[fullPath.length - 1] === '/') {
 						fullPath = fullPath.slice(0, -1);
 					}
@@ -563,6 +562,12 @@ export abstract class HttpServerModule<
 			this.logger.error({ err }, 'An error happened during the creation of the context');
 			throw err;
 		}
+	}
+
+	private joinPath(...args: Array<string>) {
+		const path = args.join('/').replace(/\/+/g, '/'); // replace multiple slashes with one
+
+		return path === '/' ? '/' : path.replace(/\/$/, ''); // remove trailing slash only if it's not '/'
 	}
 
 	/* abstract render(response, view: string, options: unknown);

--- a/packages/http-server/src/HttpServerModule.ts
+++ b/packages/http-server/src/HttpServerModule.ts
@@ -129,7 +129,7 @@ export abstract class HttpServerModule<
 						options: { path }
 					} = methodDecoratorMetadata;
 
-					let fullPath = this.joinPath(basePath, path);
+					let fullPath = this.joinPaths(basePath, path);
 					if (fullPath.length > 1 && fullPath[fullPath.length - 1] === '/') {
 						fullPath = fullPath.slice(0, -1);
 					}
@@ -564,7 +564,7 @@ export abstract class HttpServerModule<
 		}
 	}
 
-	private joinPath(...args: Array<string>) {
+	private joinPaths(...args: Array<string>) {
 		const path = args.join('/').replace(/\/+/g, '/'); // replace multiple slashes with one
 
 		return path === '/' ? '/' : path.replace(/\/$/, ''); // remove trailing slash only if it's not '/'

--- a/packages/openapi/.mocharc.js
+++ b/packages/openapi/.mocharc.js
@@ -14,5 +14,6 @@ module.exports = {
 	bail: true,
 	checkLeaks: true,
 	require: ['ts-node/register', 'source-map-support/register'],
-	spec: 'test/**/*.{js,ts}'
+	spec: 'test/**/*.{js,ts}',
+	globals: ['EdgeRuntime']
 };

--- a/packages/openapi/src/OpenAPIModule.ts
+++ b/packages/openapi/src/OpenAPIModule.ts
@@ -20,9 +20,6 @@ import pino, { Level } from 'pino';
 import { OpenAPIV3 } from 'openapi-types';
 import createDeepMerge from '@fastify/deepmerge';
 import { ClassType, PartialDeep, TypeValue } from '@davinci/reflector';
-import { promises as fs } from 'fs';
-import { join as joinPaths } from 'path';
-import * as process from 'process';
 import { generateSwaggerUiHtml } from './swaggerUi';
 
 const deepMerge = createDeepMerge();
@@ -133,19 +130,40 @@ export class OpenAPIModule extends Module {
 
 		const relativeOutputPath = this.moduleOptions.document?.output?.path;
 		if (relativeOutputPath) {
+			await this.writeOpenAPIDocument(relativeOutputPath);
+		}
+	}
+
+	public getOpenAPIDocument(): PartialDeep<OpenAPIV3.Document> {
+		return this.openAPIDoc;
+	}
+
+	public async writeOpenAPIDocument(relativeOutputPath: string) {
+		/**
+		 	This block will be dead-code-eliminated on Edge
+		 	@see https://vercel.com/docs/functions/edge-functions/edge-runtime#check-if-you're-running-on-the-edge-runtime
+		 */
+		// @ts-expect-error
+		if (typeof EdgeRuntime === 'string') {
+			throw new Error('Write operation not available in Edge Runtime');
+		} else {
 			const stringifyOptions = this.moduleOptions.document?.output.stringifyOptions;
 			const stringifiedDocument = JSON.stringify(
 				this.openAPIDoc,
 				stringifyOptions?.replacer,
 				stringifyOptions?.space
 			);
-			const outputPath = joinPaths(process.cwd(), relativeOutputPath);
+
+			const fs = await import('fs').then(m => m.promises);
+			const process = await import('process');
+
+			const outputPath = this.joinPaths(process.cwd(), relativeOutputPath);
 			await fs.writeFile(outputPath, stringifiedDocument);
 			this.logger.debug(`The OpenAPI document has been written to the local file system at path: ${outputPath}`);
 		}
 	}
 
-	async createPathAndSchema(route: Route<unknown>): Promise<void> {
+	private async createPathAndSchema(route: Route<unknown>): Promise<void> {
 		const {
 			path: origPath,
 			verb,
@@ -359,7 +377,7 @@ export class OpenAPIModule extends Module {
 		});
 	}
 
-	async registerOpenapiRoutes() {
+	private async registerOpenapiRoutes() {
 		const documentEnabled = this.moduleOptions.document?.enabled;
 		const explorerEnabled = this.moduleOptions.explorer?.enabled;
 
@@ -382,10 +400,6 @@ export class OpenAPIModule extends Module {
 				return this.httpServerModule.reply(res, swaggerUiHtml);
 			});
 		}
-	}
-
-	getOpenAPIDocument(): PartialDeep<OpenAPIV3.Document> {
-		return this.openAPIDoc;
 	}
 
 	private createJsonSchema(entityJsonSchema: EntityDefinitionJSONSchema): Partial<JSONSchema> {
@@ -457,5 +471,12 @@ export class OpenAPIModule extends Module {
 		}
 
 		return jsonSchema;
+	}
+
+	private joinPaths(...args: Array<string>) {
+		return args
+			.join('/')
+			.replace(/\/+/g, '/') // replace multiple slashes with one
+			.replace(/\/$/, ''); // remove trailing slash
 	}
 }

--- a/packages/openapi/src/OpenAPIModule.ts
+++ b/packages/openapi/src/OpenAPIModule.ts
@@ -474,9 +474,8 @@ export class OpenAPIModule extends Module {
 	}
 
 	private joinPaths(...args: Array<string>) {
-		return args
-			.join('/')
-			.replace(/\/+/g, '/') // replace multiple slashes with one
-			.replace(/\/$/, ''); // remove trailing slash
+		const path = args.join('/').replace(/\/+/g, '/'); // replace multiple slashes with one
+
+		return path === '/' ? '/' : path.replace(/\/$/, ''); // remove trailing slash only if it's not '/'
 	}
 }

--- a/packages/openapi/test/unit/OpenAPIModule.test.ts
+++ b/packages/openapi/test/unit/OpenAPIModule.test.ts
@@ -127,7 +127,7 @@ describe('OpenAPIModule', () => {
 			}
 		}
 		const openApiModule = new OpenAPIModule(openapiModuleOpts);
-		const app = new App({ logger: { level: 'error' } });
+		const app = new App({ logger: { level: 'silent' } });
 		await app.registerController(CustomerController).registerModule(new FastifyHttpServer(), openApiModule);
 
 		await app.init();
@@ -1148,6 +1148,27 @@ describe('OpenAPIModule', () => {
 			expect(writeFileStub.called).to.be.true;
 			expect(writeFileStub.args[0][0]).to.match(/path\/to\/local\/file\.json$/);
 			expect(writeFileStub.args[0][1]).to.contain('"openapi": "3.0.0"');
+		});
+
+		it('should throw an error when trying to output in a Edge environment', async () => {
+			const origValue = globalThis.EdgeRuntime;
+			globalThis.EdgeRuntime = 'edge';
+
+			await expect(
+				initApp({
+					document: {
+						output: { path: 'path/to/local/file.json', stringifyOptions: { space: 2 } },
+						spec: { info: { title: '', version: '' } }
+					}
+				})
+			).to.rejectedWith('Write operation not available in Edge Runtime');
+
+			// eslint-disable-next-line require-atomic-updates
+			globalThis.EdgeRuntime = origValue;
+
+			/* expect(writeFileStub.called).to.be.true;
+			expect(writeFileStub.args[0][0]).to.match(/path\/to\/local\/file\.json$/);
+			expect(writeFileStub.args[0][1]).to.contain('"openapi": "3.0.0"'); */
 		});
 	});
 });

--- a/packages/openapi/tsconfig.cjs.release.json
+++ b/packages/openapi/tsconfig.cjs.release.json
@@ -2,7 +2,6 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "./src",
-		"module": "commonjs",
 		"outDir": "./build-cjs",
 		"strictNullChecks": false
 	},

--- a/packages/openapi/tsconfig.esm.release.json
+++ b/packages/openapi/tsconfig.esm.release.json
@@ -2,7 +2,7 @@
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
 		"rootDir": "./src",
-		"module": "ES6",
+		"module": "ES2020",
 		"outDir": "./build-esm",
 		"strictNullChecks": false
 	},


### PR DESCRIPTION
# Motivation
This pull request aims to enhance the compatibility of our framework to support edge runtimes such as Cloudflare Workers, Vercel Edge, etc. 
Edge computing is become crucial for applications that require low latency and real-time processing. Thus, making our framework compatible with edge runtimes is a significant improvement.

# Changes Made
1. **Conditional loading of native modules:** Native Node.js modules are now conditionally loaded by checking the `globalThis.EdgeRuntime` beforehand. This ensures that native modules are only loaded in the Node.js runtime.
2. **Using native Node.js modules only when necessary:** The use of native Node.js modules has been limited to only when it is absolutely necessary. 