### PR TITLE
fix: add missing params in afterWrite hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
           matrix:
             parameters:
               mongo-version: ["4.4", "5"]
-              docker-image: ["circleci/node:14", "circleci/node:16", "cimg/node:18.16.0"]
+              docker-image: ["circleci/node:16", "cimg/node:18.16.0"]
       - publish:
           requires:
             - checkout_and_test

--- a/packages/mongoose/src/hooks.ts
+++ b/packages/mongoose/src/hooks.ts
@@ -298,7 +298,7 @@ export type Handler<Context = unknown, ModelSchema = unknown> = {
 		args: PreArgs<Context, ModelSchema> & DocumentPreArgs<Context, ModelSchema>
 	) => unknown | Promise<unknown>;
 	afterWrite: (
-		args: AfterArgs<Context, ModelSchema> & DocumentPostArgs & AfterRawResultArgs<Context>
+		args: AfterArgs<Context, ModelSchema> & DocumentPostArgs<Context, ModelSchema> & AfterRawResultArgs<Context, ModelSchema>
 	) => unknown | Promise<unknown>;
 
 	beforeDelete: (


### PR DESCRIPTION
- Adding missing parameters in `afterWrite` hook.
- Also added `findByIdAndUpdate` test to check `findOneAndUpdate` hook handler is called on that case.
- REMOVED node 14 support since circleCI was failing!!